### PR TITLE
build: pin current dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx>=3.2.1
-sphinx_rtd_theme>=0.5.0
+sphinx==3.5.4
+sphinx_rtd_theme==0.5.2


### PR DESCRIPTION
RTD [recommends](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#pinning-dependencies) pinning dependency versions to ensure reproducible builds in case an upstream dependency releases a breaking version. This PR pins both dependencies to the current version - verified by checking [build logs](https://readthedocs.org/api/v2/build/13499162.txt) for the most recent build.