### PR TITLE
fix: incorrect minimum PS rounds

### DIFF
--- a/introduction/features.rst
+++ b/introduction/features.rst
@@ -110,7 +110,7 @@ The PrivateSend process works like this:
    change address).
 #. Your wallet can repeat this process a number of times with each
    denomination. Each time the process is completed it’s called a
-   "round." The user may choose between 1-16 rounds of CoinJoin.
+   "round." The user may choose between 2-16 rounds of CoinJoin.
 #. Your funds will pass through at least the number of rounds you
    specify. Dash 0.16 includes an update known as `Random Round CoinJoin
    <https://github.com/dashpay/dash/pull/3661>`__ which will join a

--- a/wallets/dashcore/privatesend-instantsend.rst
+++ b/wallets/dashcore/privatesend-instantsend.rst
@@ -44,7 +44,7 @@ Configuration
    .. image:: img/options-privatesend.png
       :width: 300px
 
-2. Next to **PrivateSend rounds to use**, enter a value between 1-16.
+2. Next to **PrivateSend rounds to use**, enter a value between 2-16.
    Each round of PrivateSend performs one CoinJoin transaction, known as
    a denomination. Higher numbers of rounds increase your overall level
    of privacy while decreasing the chance of detection via node


### PR DESCRIPTION
This PR updates the minimum possible number of CoinJoin rounds in the GUI.