### PR TITLE
docs: bump version numbers for install docs to 0.17.0.2

### DIFF
--- a/developers/insight.rst
+++ b/developers/insight.rst
@@ -32,9 +32,9 @@ dependencies::
 Download and extract the latest version of Dash Core::
 
   cd ~
-  wget https://github.com/dashpay/dash/releases/download/v0.16.1.1/dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
-  tar -xvzf dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
-  rm dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v0.17.0.2/dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
+  tar -xvzf dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
+  rm dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
 
 Install `Dashcore Node <https://github.com/dashevo/dashcore-node>`_ and
 create your configuration::
@@ -55,7 +55,7 @@ Change paths in the configuration file as follows::
   nano dashcore-node.json
 
 - Change the value of ``datadir`` to ``../../.dashcore``
-- Change the value of ``exec`` to ``../../dashcore-0.16.1/bin/dashd``
+- Change the value of ``exec`` to ``../../dashcore-0.17.0/bin/dashd``
 - **Optionally** change the value of ``network`` to ``testnet`` if you 
   want to run Insight on testnet
 

--- a/masternodes/maintenance.rst
+++ b/masternodes/maintenance.rst
@@ -47,19 +47,19 @@ enter the following command, pasting in the address to the latest
 version of Dash Core by right clicking or pressing **Ctrl + V**::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v0.16.1.1/dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v0.17.0.2/dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
 
 Verify the integrity of your download by running the following command
 and comparing the output against the value for the file as shown in the
 ``SHA256SUMS.asc`` file::
 
-  sha256sum dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
+  sha256sum dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
 
 Extract the compressed archive and copy the new files to the directory::
 
-  tar xfv dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
-  cp -f dashcore-0.16.1/bin/dashd ~/.dashcore/
-  cp -f dashcore-0.16.1/bin/dash-cli ~/.dashcore/
+  tar xfv dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
+  cp -f dashcore-0.17.0/bin/dashd ~/.dashcore/
+  cp -f dashcore-0.17.0/bin/dash-cli ~/.dashcore/
 
 Restart Dash::
 

--- a/masternodes/setup.rst
+++ b/masternodes/setup.rst
@@ -456,7 +456,7 @@ address to the latest version of Dash Core by right clicking or pressing
 **Ctrl + V**::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v0.16.1.1/dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v0.17.0.2/dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -472,16 +472,16 @@ following keys:
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v0.16.1.1/dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v0.17.0.2/dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive and
 copy the necessary files to the directory::
 
   mkdir ~/.dashcore
-  tar xfv dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
-  cp -f dashcore-0.16.1/bin/dashd ~/.dashcore/
-  cp -f dashcore-0.16.1/bin/dash-cli ~/.dashcore/
+  tar xfv dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
+  cp -f dashcore-0.17.0/bin/dashd ~/.dashcore/
+  cp -f dashcore-0.17.0/bin/dash-cli ~/.dashcore/
 
 Create a configuration file using the following command::
 

--- a/mining/p2pool.rst
+++ b/mining/p2pool.rst
@@ -112,7 +112,7 @@ address to the latest version of Dash Core by right clicking or pressing
 **Ctrl + V**::
 
   cd ~
-  wget https://github.com/dashpay/dash/releases/download/v0.16.1.1/dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v0.17.0.2/dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -128,21 +128,21 @@ following keys:
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v0.16.1.1/dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v0.17.0.2/dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive,
 copy the necessary files to the directory and set them as executable::
 
   mkdir ~/.dashcore
-  tar xfvz dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
-  cp dashcore-0.16.1/bin/dashd .dashcore/
-  cp dashcore-0.16.1/bin/dash-cli .dashcore/
+  tar xfvz dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
+  cp dashcore-0.17.0/bin/dashd .dashcore/
+  cp dashcore-0.17.0/bin/dash-cli .dashcore/
 
 Clean up unneeded files::
 
-  rm dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
-  rm -r dashcore-0.16.1/
+  rm dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
+  rm -r dashcore-0.17.0/
 
 Create a configuration file using the following command::
 

--- a/wallets/dashcore/installation-linux.rst
+++ b/wallets/dashcore/installation-linux.rst
@@ -63,7 +63,7 @@ download as follows::
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  gpg --verify dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz.asc
 
 .. figure:: img/linux/setup-linux-gpg.png
    :width: 400px
@@ -84,13 +84,13 @@ we will extract the executable file with a graphical user interface
 
 Extract Dash Core as follows::
 
-  tar xzf dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz
+  tar xzf dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz
 
-This will create a folder named ``dashcore-0.16.1`` in the current working
+This will create a folder named ``dashcore-0.17.0`` in the current working
 directory. We will now install the executable binaries to
 ``/usr/local/bin`` using the ``install`` command::
 
-  sudo install -m 0755 -o root -g root -t /usr/local/bin dashcore-0.16.1/bin/*
+  sudo install -m 0755 -o root -g root -t /usr/local/bin dashcore-0.17.0/bin/*
 
 Start Dash Core from the terminal with the following command::
   

--- a/wallets/dashcore/installation-macos.rst
+++ b/wallets/dashcore/installation-macos.rst
@@ -51,7 +51,7 @@ download as follows::
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  gpg --verify dashcore-0.16.1.1-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-0.17.0.2-x86_64-linux-gnu.tar.gz.asc
 
 .. figure:: img/linux/setup-linux-gpg.png
    :width: 400px

--- a/wallets/dashcore/installation-windows.rst
+++ b/wallets/dashcore/installation-windows.rst
@@ -75,7 +75,7 @@ Import the key files and verify the Key-ID matches the ID above.
 
 Skip any requests to certify the certificate with your own key. Next,
 click **Decrypt/Verify...** and select the detached signature file named
-``dashcore-0.16.1.1-win64-setup.exe.asc`` in the same folder as the
+``dashcore-0.17.0.2-win64-setup.exe.asc`` in the same folder as the
 downloaded installer.
 
 .. figure:: img/windows/setup-windows-kleopatra-verify.png
@@ -84,8 +84,8 @@ downloaded installer.
    Selecting the signature file for verification
 
 If you see the first line of the message reads ``Verified
-dashcore-0.16.1.1-win64-setup.exe with
-dashcore-0.16.1.1-win64-setup.exe.asc`` then you have an authentic copy
+dashcore-0.17.0.2-win64-setup.exe with
+dashcore-0.17.0.2-win64-setup.exe.asc`` then you have an authentic copy
 of Dash Core for Windows.
 
 .. figure:: img/windows/setup-windows-kleopatra-verified.png


### PR DESCRIPTION
This PR updates versions in install/update docs to 0.17.0.2