### PR TITLE
docs: add gitian build instructions

### DIFF
--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -38,8 +38,8 @@ and only if they match, the build is accepted and uploaded to dash.org.
 
 This setup has been tested using a clean install of Ubuntu 20.04.
 
-Build
------
+Install prerequisites
+---------------------
 
 Clone required repositories::
 
@@ -53,13 +53,50 @@ Download the Mac OSX SDK::
   mkdir gitian-builder/inputs
   wget -q -O gitian-builder/inputs/MacOSX10.11.sdk.tar.gz https://bitcoincore.org/depends-sources/sdks/MacOSX10.11.sdk.tar.gz
 
+Prepare gitian
+--------------
+  
+It is only necessary to run this step once during the initial setup of your machine::
 
-Run gitian build setup::
+  # <signer> = The name associated with your PGP key
+  # <version> = Dash Core tag to build
+  ./dash/contrib/gitian-build.py --setup <signer> <version>
 
-  ./dash/contrib/gitian-build.py --setup <username> 0.17.0.0
+.. note::
 
+  Reboot after completing this this step.
 
-Run gitian build::
+Build Dash Core
+---------------
 
-  ./dash/contrib/gitian-build.py -b -n -j $(nproc) -m <amount of RAM to use> -o lwm -D <username> ./dash/contrib/gitian-build.py --setup <username> 0.17.0.0
+Run gitian build to create binaries for Linux, Mac, and Windows::
 
+  # <signer> = The name associated with your PGP key
+  # <version> = Dash Core tag to build
+  ./dash/contrib/gitian-build.py -b -n -j $(nproc) -m <MB of RAM to use> <signer> <version>
+
+When the build completes, it will put the binaries in a ``dashcore-binaries``
+folder. The ``.assert`` files and their signatures will be placed in
+``gitian.sigs/<version>/<signer>/...``.
+
+Create signatures for signed binaries
+-------------------------------------
+
+Mac and Windows binaries are signed by Dash Core Group using the relevant
+Apple/Microsoft processes. In this step, that information will be validated and
+signed by your machine. The associated ``.assert`` files and their signatures
+will be placed in ``gitian.sigs/<version>/<signer>/...`` along with the
+previously created signatures.
+
+::
+
+  # <signer> = The name associated with your PGP key
+  # <version> = Dash Core tag to build
+  ./dash/contrib/gitian-build.py -s -n -j 7 -m 18000 -o mw <signer> <version> 
+  
+Verify signatures
+-----------------
+
+::
+
+  ./dash/contrib/gitian-build.py -v <signer> <version>

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -41,6 +41,14 @@ This setup has been tested using a clean install of Ubuntu 20.04.
 Install prerequisites
 ---------------------
 
+Install apt-cacher-ng::
+
+  apt-get update
+  apt-get install -y apt-cacher-ng
+
+.. note::
+  Select ``No`` when prompted during installation
+
 Clone required repositories::
 
   git clone https://github.com/dashpay/dash

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -151,7 +151,7 @@ signatures for unsigned binaries created in the previous step.
   ./dash/contrib/gitian-build.py -s -n -j $(nproc) -m <MB of RAM to use> -o mw <signer> <version> 
 
 Verify signatures
------------------
+=================
 
 The `gitian.sigs repository <https://github.com/dashpay/gitian.sigs/>`_ contains
 deterministic build results signed by multiple Core developers for each release.
@@ -195,3 +195,54 @@ successfully, you will also see your own signatures with an ``OK`` status also.
   gpg:          There is no indication that the signature belongs to the owner.
   Primary key fingerprint: 3F5D 48C9 F002 93CD 365A  3A98 8359 2BD1 400D 58D9
   UdjinM6: OK
+
+Upload signatures
+=================
+
+After successfully building the binaries, signing them, and verifying the
+signatures, you can optionally contribute them to the `gitian.sigs repository
+<https://github.com/dashpay/gitian.sigs/>`_ via a pull request on GitHub.
+
+Initial setup
+-------------
+
+Since the official gitian.sigs repository has restricted write access, create a
+fork of it via GitHub and add your fork as a remote repository::
+
+  git remote add me https://github.com/<your GitHub username>/gitian.sigs
+
+The first time you contribute signatures, also put a copy of your public key in
+the ``gitian-keys`` folder of the repository so others can easily verify your
+signature. Your public key can be exported to a file using the following
+command::
+
+  # <signer> = The name associated with your PGP key
+  # Example: gpg --output alice.pgp --armor --export alice
+  gpg --output <signer>.pgp --armor --export <signer>
+
+Adding your signatures
+----------------------
+
+Create a new branch for the version that was built::
+
+  # Example: git checkout -b 0.17.0.2-alice
+  git checkout -b <version>-<signer>
+
+Add and commit the ``*.assert`` and ``*.assert.sig`` files created by the build
+process. They will be located in the following folders::
+
+  <version>-linux/<signer>/*
+  <version>-osx-signed/<signer>/*
+  <version>-osx-unsigned/<signer>/*
+  <version>-win-signed/<signer>/*
+  <version>-win-unsigned/<signer>/*
+
+Push to your fork of the gitian.sigs repository on GitHub::
+
+  # "me" references the name of the remote repository added during initial setup
+  git push me
+
+Go to `GitHub <https://github.com/dashpay/gitian.sigs/pulls>`_ and open a pull
+request to the ``master`` branch of the upstream repository. The pull request
+will be reviewed by Dash Core developers and merged if everything checks out.
+Thanks for contributing!

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -36,7 +36,8 @@ following a specific descriptor ("recipe"), cryptographically sign the
 result, and upload the resulting signature. These results are compared
 and only if they match, the build is accepted and uploaded to dash.org.
 
-This setup has been tested using a clean install of Ubuntu 20.04.
+This setup has been tested using a clean install of Ubuntu 20.04. All commands
+were run using the "root" user.
 
 Install prerequisites
 ---------------------
@@ -97,10 +98,48 @@ previously created signatures.
   # <signer> = The name associated with your PGP key
   # <version> = Dash Core tag to build
   ./dash/contrib/gitian-build.py -s -n -j $(nproc) -m <MB of RAM to use> -o mw <signer> <version> 
-  
+
 Verify signatures
 -----------------
 
-::
+The `gitian.sigs repository <https://github.com/dashpay/gitian.sigs/>`_ contains
+deterministic build results signed by multiple Core developers for each release.
+Run the following command to verify that your build matches the official
+release::
 
   ./dash/contrib/gitian-build.py -v <signer> <version>
+
+You should get a result similar to the following for Linux, Windows, MacOS,
+Signed Windows, and Signed MacOS. Assuming the previous steps completed
+successfully, you will also see your own signatures with an ``OK`` status also.
+
+::
+
+  Verifying v0.17.0.2 Linux
+
+  gpg: Signature made Tue 18 May 2021 10:59:02 PM EDT
+  gpg:                using RSA key 29590362EC878A81FD3C202B52527BEDABE87984
+  gpg: Good signature from "Pasta <pasta@dashboost.org>" [unknown]
+  gpg: WARNING: This key is not certified with a trusted signature!
+  gpg:          There is no indication that the signature belongs to the owner.
+  Primary key fingerprint: 2959 0362 EC87 8A81 FD3C  202B 5252 7BED ABE8 7984
+  pasta: OK
+
+  gpg: Signature made Tue 18 May 2021 10:23:19 PM EDT
+  gpg:                using RSA key CF9A554A36B7950BB648A15DA0078C72B1777616
+  gpg:                issuer "xdustinfacex@gmail.com"
+  gpg: Good signature from "Dustinface <xdustinfacex@gmail.com>" [unknown]
+  gpg: WARNING: This key is not certified with a trusted signature!
+  gpg:          There is no indication that the signature belongs to the owner.
+  Primary key fingerprint: CF9A 554A 36B7 950B B648  A15D A007 8C72 B177 7616
+  dustinface: OK
+
+  gpg: Signature made Wed 19 May 2021 06:48:36 AM EDT
+  gpg:                using RSA key 3F5D48C9F00293CD365A3A9883592BD1400D58D9
+  gpg: Good signature from "UdjinM6 <UdjinM6@dash.org>" [unknown]
+  gpg:                 aka "UdjinM6 <UdjinM6@dashpay.io>" [unknown]
+  gpg:                 aka "UdjinM6 <UdjinM6@gmail.com>" [unknown]
+  gpg: WARNING: This key is not certified with a trusted signature!
+  gpg:          There is no indication that the signature belongs to the owner.
+  Primary key fingerprint: 3F5D 48C9 F002 93CD 365A  3A98 8359 2BD1 400D 58D9
+  UdjinM6: OK

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -51,9 +51,16 @@ see prompts for user information, but this can be left blank. Alternatively, an
 existing user can be used on systems that are already in use (e.g. your existing
 development system).
 
-Add the user to the sudo group so they can perform commands as root::
+Create a ``docker`` group on the system. This group will be used by Docker
+processes and also will enable non-root users to run the Docker commands used by
+the build process::
 
-  usermod -aG sudo <username>
+  groupadd docker
+
+Add the user to the sudo and docker groups so they can perform commands as
+root and run docker commands::
+
+  usermod -aG sudo,docker <username>
 
 Install prerequisites
 ---------------------
@@ -96,18 +103,6 @@ It is only necessary to run this step during the initial setup of your machine::
   # <signer> = The name associated with your PGP key
   # <version> = Dash Core tag to build (exclude the leading "v")
   # Example: ./dash/contrib/gitian-build.py --setup alice 0.17.0.2
-  ./dash/contrib/gitian-build.py --setup <signer> <version>
-
-This will install Docker, but then fail with an error like: ``Got permission
-denied while trying to connect to the Docker daemon socket...```. This occurs if
-``<username>`` is not in the ``docker`` group. Add the user to the docker group
-and refresh the environment::
-
-  sudo usermod -aG docker $USER
-  newgrp docker
-
-Run the setup a second time to complete setup::
-
   ./dash/contrib/gitian-build.py --setup <signer> <version>
 
 Build Dash Core

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -36,21 +36,44 @@ following a specific descriptor ("recipe"), cryptographically sign the
 result, and upload the resulting signature. These results are compared
 and only if they match, the build is accepted and uploaded to dash.org.
 
-This setup has been tested using a clean install of Ubuntu 20.04. All commands
-were run using the "root" user.
+This setup has been tested using a clean install of Ubuntu 20.04. Start by
+logging in as the "root" user. Create a new user with the following command, replacing ``<username>`` with a
+username of your choice::
+
+  adduser <username>
+
+You will be prompted for a password. Enter and confirm using a new password
+(different to your root password) and store it in a safe place. You will also
+see prompts for user information, but this can be left blank. Once the user has
+been created, we will add them to the sudo group so they can perform commands as
+root::
+
+  usermod -aG sudo <username>
 
 Install prerequisites
 ---------------------
 
+While still logged in as root, update the system from the Ubuntu package
+repository::
+
+  apt update
+  apt upgrade
+
+The system will show a list of upgradable packages. Press **Y** and
+**Enter** to install the packages.
+
 Install apt-cacher-ng::
 
-  apt-get update
-  apt-get install -y apt-cacher-ng
+  apt install -y apt-cacher-ng
 
 .. note::
   Select ``No`` when asked ``Allow HTTP tunnels through Apt-Cacher NG?`` during installation.
 
-Clone required repositories::
+After installing these updates, reboot the system::
+
+  reboot
+
+Login as <username> and clone required repositories::
 
   git clone https://github.com/dashpay/dash
   git clone https://github.com/devrandom/gitian-builder
@@ -65,10 +88,21 @@ Download the Mac OSX SDK::
 Prepare gitian
 --------------
   
-It is only necessary to run this step once during the initial setup of your machine::
+It is only necessary to run this step during the initial setup of your machine::
 
   # <signer> = The name associated with your PGP key
   # <version> = Dash Core tag to build
+  ./dash/contrib/gitian-build.py --setup <signer> <version>
+
+This will install Docker, but then fail as ``<username>`` will not be part of
+the ``docker`` group. Add the user to the docker group and refresh the
+environment::
+
+  sudo usermod -aG docker $USER
+  newgrp docker
+
+Run the setup a second time to complete setup::
+
   ./dash/contrib/gitian-build.py --setup <signer> <version>
 
 Build Dash Core

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -70,10 +70,6 @@ It is only necessary to run this step once during the initial setup of your mach
   # <version> = Dash Core tag to build
   ./dash/contrib/gitian-build.py --setup <signer> <version>
 
-.. note::
-
-  Reboot after completing this this step.
-
 Build Dash Core
 ---------------
 

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -47,10 +47,9 @@ replacing ``<username>`` with a username of your choice::
 
 You will be prompted for a password. Enter and confirm using a new password
 (different to your root password) and store it in a safe place. You will also
-see prompts for user information, but this can be left blank. 
-
-Alternatively, an existing user can be used on systems that are already in use
-(e.g. your existing development system).
+see prompts for user information, but this can be left blank. Alternatively, an
+existing user can be used on systems that are already in use (e.g. your existing
+development system).
 
 Add the user to the sudo group so they can perform commands as root::
 
@@ -94,7 +93,7 @@ It is only necessary to run this step during the initial setup of your machine::
   # <version> = Dash Core tag to build
   ./dash/contrib/gitian-build.py --setup <signer> <version>
 
-This will install Docker, but then fail with an error like ``Got permission
+This will install Docker, but then fail with an error like: ``Got permission
 denied while trying to connect to the Docker daemon socket...```. This occurs if
 ``<username>`` is not in the ``docker`` group. Add the user to the docker group
 and refresh the environment::
@@ -115,12 +114,12 @@ Run gitian build to create binaries for Linux, Mac, and Windows::
   # <version> = Dash Core tag to build
   ./dash/contrib/gitian-build.py -b -n -j $(nproc) -m <MB of RAM to use> <signer> <version>
 
-.. note::
+.. warning::
   These instructions assume that a PGP key for <signer> exists on the build
   system. If the expected key is not found, the script will fail at the signing
   step with a message including::
 
-    gpg: skipped "gitian": No secret key
+    gpg: skipped "<signer>": No secret key
     gpg: signing failed: No secret key
 
 When the build completes, it will put the binaries in a ``dashcore-binaries``

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -105,6 +105,12 @@ It is only necessary to run this step during the initial setup of your machine::
   # Example: ./dash/contrib/gitian-build.py --setup alice 0.17.0.2
   ./dash/contrib/gitian-build.py --setup <signer> <version>
 
+.. note::
+  The ``signer`` parameter should be set to the value provided for "Real name"
+  when generating a key with GPG. See the `GnuPrivacyGuard Howto
+  <https://help.ubuntu.com/community/GnuPrivacyGuardHowto#Generating_an_OpenPGP_Key>`_
+  for details on how to generate a key if you don't already have one.
+
 Build Dash Core
 ---------------
 

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -118,7 +118,8 @@ Run gitian build to create binaries for Linux, Mac, and Windows::
 
   # <signer> = The name associated with your PGP key
   # <version> = Dash Core tag to build (exclude the leading "v")
-  # Example: ./dash/contrib/gitian-build.py -b -n -j $(nproc) -m 16000 alice 0.17.0.2
+  # Example: Build binaries for all OSes, use all available cores and 16 GB RAM
+  #   ./dash/contrib/gitian-build.py -b -n -j $(nproc) -m 16000 alice 0.17.0.2
   ./dash/contrib/gitian-build.py -b -n -j $(nproc) -m <MB of RAM to use> <signer> <version>
 
 .. warning::

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -36,8 +36,30 @@ following a specific descriptor ("recipe"), cryptographically sign the
 result, and upload the resulting signature. These results are compared
 and only if they match, the build is accepted and uploaded to dash.org.
 
-Instructions on how to build Dash Core 0.13.0 will appear here once the
-Docker build system for Gitian is available. Instructions to create
-deterministic builds of Dash Core 0.12.3 or older are available `here
-<https://docs.dash.org/en/0.12.3/developers/compiling.html#gitian-build>`__ 
-on a previous version of this page.
+This setup has been tested using a clean install of Ubuntu 20.04.
+
+Build
+-----
+
+Clone required repositories::
+
+  git clone https://github.com/dashpay/dash
+  git clone https://github.com/devrandom/gitian-builder
+  git clone https://github.com/dashpay/dash-detached-sigs
+  git clone https://github.com/dashpay/gitian.sigs
+
+Download the Mac OSX SDK::
+
+  mkdir gitian-builder/inputs
+  wget -q -O gitian-builder/inputs/MacOSX10.11.sdk.tar.gz https://bitcoincore.org/depends-sources/sdks/MacOSX10.11.sdk.tar.gz
+
+
+Run gitian build setup::
+
+  ./dash/contrib/gitian-build.py --setup <username> 0.17.0.0
+
+
+Run gitian build::
+
+  ./dash/contrib/gitian-build.py -b -n -j $(nproc) -m <amount of RAM to use> -o lwm -D <username> ./dash/contrib/gitian-build.py --setup <username> 0.17.0.0
+

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -115,6 +115,14 @@ Run gitian build to create binaries for Linux, Mac, and Windows::
   # <version> = Dash Core tag to build
   ./dash/contrib/gitian-build.py -b -n -j $(nproc) -m <MB of RAM to use> <signer> <version>
 
+.. note::
+  These instructions assume that a PGP key for <signer> exists on the build
+  system. If the expected key is not found, the script will fail at the signing
+  step with a message including::
+
+    gpg: skipped "gitian": No secret key
+    gpg: signing failed: No secret key
+
 When the build completes, it will put the binaries in a ``dashcore-binaries``
 folder. The ``.assert`` files and their signatures will be placed in
 ``gitian.sigs/<version>/<signer>/...``.

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -47,7 +47,7 @@ Install apt-cacher-ng::
   apt-get install -y apt-cacher-ng
 
 .. note::
-  Select ``No`` when prompted during installation
+  Select ``No`` when asked ``Allow HTTP tunnels through Apt-Cacher NG?`` during installation.
 
 Clone required repositories::
 
@@ -100,7 +100,7 @@ previously created signatures.
 
   # <signer> = The name associated with your PGP key
   # <version> = Dash Core tag to build
-  ./dash/contrib/gitian-build.py -s -n -j 7 -m 18000 -o mw <signer> <version> 
+  ./dash/contrib/gitian-build.py -s -n -j $(nproc) -m <MB of RAM to use> -o mw <signer> <version> 
   
 Verify signatures
 -----------------

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -69,9 +69,13 @@ Install apt-cacher-ng::
   apt install -y apt-cacher-ng
 
 .. note::
-  Select ``No`` when asked ``Allow HTTP tunnels through Apt-Cacher NG?`` during installation.
+  Select ``No`` when asked ``Allow HTTP tunnels through Apt-Cacher NG?`` during
+  installation.
 
-After installing these updates, reboot the system, login as <username>, and
+  Note: you may also need to open port 3142 if you have a firewall enabled on
+  your system (e.g. ``ufw allow 3142/tcp``).
+
+After installing these updates, reboot the system, login as ``<username>``, and
 clone required repositories::
 
   git clone https://github.com/dashpay/dash
@@ -133,7 +137,7 @@ Mac and Windows binaries are signed by Dash Core Group using the relevant
 Apple/Microsoft processes. In this step, that information will be validated and
 signed by your machine. The associated ``.assert`` files and their signatures
 will be placed in ``gitian.sigs/<version>/<signer>/...`` along with the
-previously created signatures.
+signatures for unsigned binaries created in the previous step.
 
 ::
 

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -57,10 +57,7 @@ While still logged in as root, update the system from the Ubuntu package
 repository::
 
   apt update
-  apt upgrade
-
-The system will show a list of upgradable packages. Press **Y** and
-**Enter** to install the packages.
+  apt upgrade -y
 
 Install apt-cacher-ng::
 
@@ -69,11 +66,8 @@ Install apt-cacher-ng::
 .. note::
   Select ``No`` when asked ``Allow HTTP tunnels through Apt-Cacher NG?`` during installation.
 
-After installing these updates, reboot the system::
-
-  reboot
-
-Login as <username> and clone required repositories::
+After installing these updates, reboot the system, login as <username>, and
+clone required repositories::
 
   git clone https://github.com/dashpay/dash
   git clone https://github.com/devrandom/gitian-builder
@@ -94,9 +88,10 @@ It is only necessary to run this step during the initial setup of your machine::
   # <version> = Dash Core tag to build
   ./dash/contrib/gitian-build.py --setup <signer> <version>
 
-This will install Docker, but then fail as ``<username>`` will not be part of
-the ``docker`` group. Add the user to the docker group and refresh the
-environment::
+This will install Docker, but then fail with an error like ``Got permission
+denied while trying to connect to the Docker daemon socket...```. This occurs if
+``<username>`` is not in the ``docker`` group. Add the user to the docker group
+and refresh the environment::
 
   sudo usermod -aG docker $USER
   newgrp docker

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -10,31 +10,31 @@ Compiling Dash Core
 
 While Dash offers stable binary builds on the `website
 <https://www.dash.org/downloads/>`_ and on `GitHub
-<https://github.com/dashpay/dash/releases>`_, and development builds
-using `GitLab CI <https://gitlab.com/dashpay/dash/pipelines>`_,  many
-users will also be interested in building Dash binaries for themselves.
-This process has been greatly simplified with the release of Dash Core
-0.13.0, and users who do not required deterministic builds can typically
-follow the `generic build notes <https://github.com/dashpay/dash/blob/develop/doc/build-generic.md>`__
-available on GitHub to compile or cross-compile Dash for any platform.
+<https://github.com/dashpay/dash/releases>`_, and development builds using
+`GitLab CI <https://gitlab.com/dashpay/dash/pipelines>`_,  many users will also
+be interested in building Dash binaries for themselves. This process has been
+greatly simplified with the release of Dash Core 0.13.0, and users who do not
+required deterministic builds can typically follow the `generic build notes
+<https://github.com/dashpay/dash/blob/develop/doc/build-generic.md>`__ available
+on GitHub to compile or cross-compile Dash for any platform.
 
 The instructions to build Dash Core 0.12.3 or older are available `here
-<https://docs.dash.org/en/0.12.3/developers/compiling.html>`__ on a
-previous version of this page.
+<https://docs.dash.org/en/0.12.3/developers/compiling.html>`__ on a previous
+version of this page.
 
 .. _gitian-build:
 
 Gitian
 ======
 
-Gitian is the deterministic build process that is used to build the Dash
-Core executables. It provides a way to be reasonably sure that the
-executables are really built from the source on GitHub. It also makes
-sure that the same, tested dependencies are used and statically built
-into the executable. Multiple developers build the source code by
-following a specific descriptor ("recipe"), cryptographically sign the
-result, and upload the resulting signature. These results are compared
-and only if they match, the build is accepted and uploaded to dash.org.
+Gitian is the deterministic build process that is used to build the Dash Core
+executables. It provides a way to be reasonably sure that the executables are
+really built from the source on GitHub. It also makes sure that the same, tested
+dependencies are used and statically built into the executable. Multiple
+developers build the source code by following a specific descriptor ("recipe"),
+cryptographically sign the result, and upload the resulting signature. These
+results are compared and only if they match, the build is accepted and uploaded
+to dash.org.
 
 Build process
 =============

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -94,7 +94,8 @@ Prepare gitian
 It is only necessary to run this step during the initial setup of your machine::
 
   # <signer> = The name associated with your PGP key
-  # <version> = Dash Core tag to build
+  # <version> = Dash Core tag to build (exclude the leading "v")
+  # Example: ./dash/contrib/gitian-build.py --setup alice 0.17.0.2
   ./dash/contrib/gitian-build.py --setup <signer> <version>
 
 This will install Docker, but then fail with an error like: ``Got permission
@@ -115,7 +116,8 @@ Build Dash Core
 Run gitian build to create binaries for Linux, Mac, and Windows::
 
   # <signer> = The name associated with your PGP key
-  # <version> = Dash Core tag to build
+  # <version> = Dash Core tag to build (exclude the leading "v")
+  # Example: ./dash/contrib/gitian-build.py -b -n -j $(nproc) -m 16000 alice 0.17.0.2
   ./dash/contrib/gitian-build.py -b -n -j $(nproc) -m <MB of RAM to use> <signer> <version>
 
 .. warning::
@@ -142,7 +144,8 @@ signatures for unsigned binaries created in the previous step.
 ::
 
   # <signer> = The name associated with your PGP key
-  # <version> = Dash Core tag to build
+  # <version> = Dash Core tag to build (exclude the leading "v")
+  # Example: ./dash/contrib/gitian-build.py -s -n -j $(nproc) -m 16000 -o mw alice 0.17.0.2
   ./dash/contrib/gitian-build.py -s -n -j $(nproc) -m <MB of RAM to use> -o mw <signer> <version> 
 
 Verify signatures
@@ -153,6 +156,7 @@ deterministic build results signed by multiple Core developers for each release.
 Run the following command to verify that your build matches the official
 release::
 
+  # Example: ./dash/contrib/gitian-build.py -v alice 0.17.0.2
   ./dash/contrib/gitian-build.py -v <signer> <version>
 
 You should get a result similar to the following for Linux, Windows, MacOS,

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -36,17 +36,23 @@ following a specific descriptor ("recipe"), cryptographically sign the
 result, and upload the resulting signature. These results are compared
 and only if they match, the build is accepted and uploaded to dash.org.
 
+Build process
+=============
+
 This setup has been tested using a clean install of Ubuntu 20.04. Start by
-logging in as the "root" user. Create a new user with the following command, replacing ``<username>`` with a
-username of your choice::
+logging in as the "root" user. Create a new user with the following command,
+replacing ``<username>`` with a username of your choice::
 
   adduser <username>
 
 You will be prompted for a password. Enter and confirm using a new password
 (different to your root password) and store it in a safe place. You will also
-see prompts for user information, but this can be left blank. Once the user has
-been created, we will add them to the sudo group so they can perform commands as
-root::
+see prompts for user information, but this can be left blank. 
+
+Alternatively, an existing user can be used on systems that are already in use
+(e.g. your existing development system).
+
+Add the user to the sudo group so they can perform commands as root::
 
   usermod -aG sudo <username>
 


### PR DESCRIPTION
Explains how to setup for gitian builds and use the gitian-build.py script to complete builds.
https://dash-docs--98.org.readthedocs.build/en/98/developers/compiling.html