### PR TITLE
docs: add rpcbind to dash.conf examples

### DIFF
--- a/masternodes/setup.rst
+++ b/masternodes/setup.rst
@@ -496,6 +496,7 @@ follows::
   rpcuser=XXXXXXXXXXXXX
   rpcpassword=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
   rpcallowip=127.0.0.1
+  rpcbind=0.0.0.0
   #----
   listen=1
   server=1

--- a/mining/p2pool.rst
+++ b/mining/p2pool.rst
@@ -157,6 +157,7 @@ follows::
   rpcuser=XXXXXXXXXXXXX
   rpcpassword=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
   rpcallowip=127.0.0.1
+  rpcbind=0.0.0.0
   #----
   listen=1
   server=1

--- a/network/electrumx-server.rst
+++ b/network/electrumx-server.rst
@@ -43,6 +43,7 @@ not present, add them as shown below.
   rpcuser=XXXXXXXXXXXXX
   rpcpassword=XXXXXXXXXXXXXXXXXXXXXXXXXXXX
   rpcallowip=127.0.0.1
+  rpcbind=0.0.0.0
 
 Replace the fields marked with ``XXXXXXX`` as follows:
 


### PR DESCRIPTION
I've seen a number of people having issues that are resolved by configuring `rpcbind`. Added it to our example conf files. It's not entirely clear to me if `0.0.0.0` is the right value.