### PR TITLE
Improve update docs

### DIFF
--- a/masternodes/setup-testnet.rst
+++ b/masternodes/setup-testnet.rst
@@ -511,12 +511,13 @@ Masternode Update
 -----------------
 
 You can use ``dashmate`` to update your masternode as follows. The
-``git`` commands optionally also ensure you are using the latest stable
+``git`` and ``npm`` commands optionally also ensure you are using the latest stable
 version of dashmate::
 
   dashmate stop
   git checkout master
   git pull
+  npm ci
   dashmate update
   dashmate start
 

--- a/masternodes/setup-testnet.rst
+++ b/masternodes/setup-testnet.rst
@@ -447,8 +447,10 @@ Open PuTTY or a console again and connect using the username and
 password you just created for your new, non-root user. Begin by
 installing dashmate dependencies::
 
-  curl -sL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
-  sudo apt install -y nodejs git docker.io docker-compose  
+  sudo apt install -y git curl docker.io docker-compose
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+  source ~/.bashrc
+  nvm install --lts
 
 Add your current user to the docker group, ensure docker starts on boot
 and refresh the environment::
@@ -463,8 +465,8 @@ CLI::
 
   git clone -b master https://github.com/dashevo/dashmate.git
   cd dashmate
-  npm install
-  sudo npm link
+  npm ci
+  npm link
 
 Run the interactive setup wizard::
 
@@ -508,9 +510,13 @@ to enable your masternode.
 Masternode Update
 -----------------
 
-You can use ``dashmate`` to update your masternode as follows::
+You can use ``dashmate`` to update your masternode as follows. The
+``git`` commands optionally also ensure you are using the latest stable
+version of dashmate::
 
   dashmate stop
+  git checkout master
+  git pull
   dashmate update
   dashmate start
 

--- a/masternodes/setup-testnet.rst
+++ b/masternodes/setup-testnet.rst
@@ -510,14 +510,32 @@ to enable your masternode.
 Masternode Update
 -----------------
 
-You can use ``dashmate`` to update your masternode as follows. The
-``git`` and ``npm`` commands optionally also ensure you are using the latest stable
-version of dashmate::
+You can use ``dashmate`` to update minor versions of the software on
+your masternode as follows::
+
+  dashmate stop
+  dashmate update
+  dashmate start
+
+Adding the following ``git`` and ``npm`` commands optionally also
+ensures you are using the latest stable version of dashmate::
 
   dashmate stop
   git checkout master
   git pull
   npm ci
+  dashmate update
+  dashmate start
+
+Adding the following command will drop all data from Dash Platform
+(necessary if Platform has been wiped) and restart with the latest
+version::
+
+  dashmate stop
+  git checkout master
+  git pull
+  npm ci
+  dashmate reset --platform-only
   dashmate update
   dashmate start
 


### PR DESCRIPTION
This PR:
- switches the NVM installer from NodeSource to NVM (removes sudo requirement for `npm link`)
- updates the update docs to update dashmate as well as the images it runs