### PR TITLE
docs: use gitian-build from the version being built

### DIFF
--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -100,8 +100,15 @@ Download the Mac OSX SDK::
 
 Prepare gitian
 --------------
-  
-It is only necessary to run this step during the initial setup of your machine::
+
+It is only necessary to run this step during the initial setup of your machine.
+Checkout the tag associated with the Dash Core version you plan to build::
+
+  # <version> = Dash Core tag to build
+  # Example: git checkout v0.17.0.0
+  git checkout <version>
+
+Run the gitian-build setup routine to prepare your environment::
 
   # <signer> = The name associated with your PGP key
   # <version> = Dash Core tag to build (exclude the leading "v")

--- a/developers/compiling.rst
+++ b/developers/compiling.rst
@@ -106,7 +106,9 @@ Checkout the tag associated with the Dash Core version you plan to build::
 
   # <version> = Dash Core tag to build
   # Example: git checkout v0.17.0.0
+  cd dash
   git checkout <version>
+  cd ..
 
 Run the gitian-build setup routine to prepare your environment::
 


### PR DESCRIPTION
There may be compatibility issues if attempting to use gitian-build from a different version

Preview: https://dash-docs--136.org.readthedocs.build/en/136/developers/compiling.html#prepare-gitian