### PR TITLE
chore: remove use of deprecated docker-compose

### DIFF
--- a/masternodes/setup-testnet.rst
+++ b/masternodes/setup-testnet.rst
@@ -449,8 +449,6 @@ installing dashmate dependencies::
   curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh
   sudo usermod -aG docker $USER
   newgrp docker
-  sudo apt install python3-pip
-  sudo pip3 install docker-compose
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
   source ~/.bashrc
   nvm install 16


### PR DESCRIPTION
This PR removes the `docker-compose` requirement. Docker Compose V1 (Python) has been deprecated and replaced with Docker Compose V2 (Go) which now ships by default with both Docker Desktop and the convenience script we use to install Docker on Linux. This PR can be merged when support for Docker Compose V2 is merged into Dashmate ([dashevo/platform #422](https://github.com/dashevo/platform/pull/422)).