### PR TITLE
docs: add authenticity check to MN maintenance

### DIFF
--- a/masternodes/maintenance.rst
+++ b/masternodes/maintenance.rst
@@ -42,19 +42,29 @@ Then stop Dash running::
 
 Visit the `GitHub releases page
 <https://github.com/dashpay/dash/releases>`_ and copy the link to the
-latest x86_64-linux-gnu version. Go back to your terminal window and
+latest `x86_64-linux-gnu` version. Go back to your terminal window and
 enter the following command, pasting in the address to the latest
 version of Dash Core by right clicking or pressing **Ctrl + V**::
 
   cd /tmp
   wget https://github.com/dashpay/dash/releases/download/v18.0.1/dashcore-18.0.1-x86_64-linux-gnu.tar.gz
-  wget https://github.com/dashpay/dash/releases/download/v18.0.1/SHA256SUMS.asc
 
-Verify the integrity of your download by running the following command
-and comparing the output against the value for the file as shown in the
-``SHA256SUMS.asc`` file::
+Verify the authenticity of your download by checking its detached
+signature against the public key published by the Dash Core development
+team. All releases of Dash are signed using GPG with one of the
+following keys:
 
-  sha256sum dashcore-18.0.1-x86_64-linux-gnu.tar.gz
+- Alexander Block (codablock) with the key ``63A9 6B40 6102 E091``,
+  `verifiable here on Keybase <https://keybase.io/codablock>`__
+- Pasta (pasta) with the key ``5252 7BED ABE8 7984``, `verifiable here
+  on Keybase <https://keybase.io/pasta>`__
+
+::
+
+  curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
+  curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
+  wget https://github.com/dashpay/dash/releases/download/v18.0.1/dashcore-18.0.1-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-18.0.1-x86_64-linux-gnu.tar.gz.asc
 
 Extract the compressed archive and copy the new files to the directory::
 


### PR DESCRIPTION
As requested [on Discord by dashfriend](https://discord.com/channels/484546513507188745/496953691203698703/1011180601342185492). Replaces the shas256 check with the signature check used in https://docs.dash.org/en/stable/masternodes/setup.html#manual-installation.

Preview: https://dash-docs--147.org.readthedocs.build/en/147/masternodes/maintenance.html#manual-update