### PR TITLE
docs: remove Dash Nexus link

### DIFF
--- a/governance/using.rst
+++ b/governance/using.rst
@@ -352,7 +352,6 @@ at any time before the voting deadline. The following sites and tools
 are available to view and manage proposals and voting:
 
 - `DashCentral <https://www.dashcentral.org/budget>`__
-- `Dash Nexus <https://app.dashnexus.org/>`__
 - `Dash Ninja - Governance <https://www.dashninja.pl/governance.html>`__
 - `Dash Masternode Tool - Proposals <https://github.com/Bertrand256/dash-masternode-tool/releases>`__
 


### PR DESCRIPTION
Dash Nexus has been unavailable for quite some time. Removes a (dead) link to it.