### PR TITLE
chore: update dependencies

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -58,7 +58,7 @@ release = u'latest'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# language = None
 
 locale_dirs = ['locale/']
 gettext_compact = False 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==3.5.4
+sphinx==5.3.0
 sphinx-copybutton==0.5.0
 sphinx_rtd_theme==1.1.1
 jinja2==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==3.5.4
 sphinx-copybutton==0.5.0
-sphinx_rtd_theme==0.5.2
+sphinx_rtd_theme==1.1.1
 jinja2==3.0.0


### PR DESCRIPTION
This change is to bring us up to the current version of Sphinx (and our current theme). The version we're on currently is about 18 months old and there have been 2 major releases since then. Please click around a bit on the PR build in case some issue shows up on your OS/browser combo that I don't see.

Once we merge this, I will also trigger builds on the translation sites to make sure they continue to operate correctly as well. Not anticipating any issues, but you never know.

PR Build site: https://dash-docs--165.org.readthedocs.build/en/165/