### PR TITLE
build: update build settings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,11 @@
 # Required
 version: 2
 
+build:
+   os: "ubuntu-22.04"
+   tools:
+      python: "3.8"
+
 python:
-   version: 3.7
    install:
       - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,6 @@ build:
    tools:
       python: "3.10"
 
-
 python:
    install:
       - requirements: requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,8 @@ version: 2
 build:
    os: "ubuntu-22.04"
    tools:
-      python: "3.8"
+      python: "3.10"
+
 
 python:
    install:


### PR DESCRIPTION
Switch to using Python 3.10. Python 3.7 support ends in ~6 months while 3.10 is good until 2026 (https://endoflife.date/python). Python 3.11 is only a few weeks old so there could be compatibility issues with some extensions at this point.

Also explicitly set which OS is used for the build. Ubuntu 22.04 has been out for >6 mo and will be supported until 2027 (https://wiki.ubuntu.com/Releases) so it seems like a reasonable choice.

PR build: https://dash-docs--166.org.readthedocs.build/en/166/index.html