### PR TITLE
style: update to pydata theme

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -80,32 +80,33 @@ todo_include_todos = False
 
 
 
-import sphinx_rtd_theme
-
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx_rtd_theme',
     'sphinx_copybutton',
 ]
 
-html_theme = 'sphinx_rtd_theme'
-#html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "pydata_sphinx_theme"
 
 # Theme options
 html_theme_options = {
-    # 'typekit_id': 'hiw1hhg',
-    # 'analytics_id': '',
-    # 'sticky_navigation': True  # Set to False to disable the sticky nav while scrolling.
-    'logo_only': True,  # if we have a html_logo below, this shows /only/ the logo with no title text
-    'collapse_navigation': False,  # Collapse navigation (False makes it tree-like)
-    'display_version': False,  # Display the docs version
-    # 'navigation_depth': 4,  # Depth of the headers shown in the navigation bar
+    "external_links": [
+        {"name": "Dash.org", "url": "https://www.dash.org"},
+    ],
+    "use_edit_page_button": True,    
 }
 
-html_logo = 'img/dash_logo_white.png'
+html_context = {
+    # "github_url": "https://github.com", # or your GitHub Enterprise site
+    "github_user": "dashpay",
+    "github_repo": "docs",
+    "github_version": "18.0.0",
+    "doc_path": "",
+}
+
+html_logo = 'img/dash_logo.png'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/conf.py
+++ b/conf.py
@@ -95,7 +95,8 @@ html_theme_options = {
     "external_links": [
         {"name": "Dash.org", "url": "https://www.dash.org"},
     ],
-    "use_edit_page_button": True,    
+    "use_edit_page_button": True,
+    "github_url": "https://github.com/dashpay/docs",
 }
 
 html_context = {

--- a/conf.py
+++ b/conf.py
@@ -93,11 +93,15 @@ html_theme = "pydata_sphinx_theme"
 # Theme options
 html_theme_options = {
     "external_links": [
+        {"name": "Core docs", "url": "https://dashcore.readme.io/"},
+        {"name": "Platform docs", "url": "https://dashplatform.readme.io"},
         {"name": "Dash.org", "url": "https://www.dash.org"},
     ],
     "use_edit_page_button": True,
     "github_url": "https://github.com/dashpay/docs",
-    "announcement": "<p>Testing pydata theme for <a href='https://docs.dash.org'>docs.dash.org!</a></p>"
+    "announcement": "<p>Testing pydata theme for <a href='https://docs.dash.org'>docs.dash.org!</a></p>",
+    "show_toc_level": 2,
+    "show_nav_level": 2,
 }
 
 html_context = {
@@ -139,11 +143,15 @@ html_static_path = ['_static']
 #
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
+# html_sidebars = {
+#     '**': [
+#         'relations.html',  # needs 'show_related': True theme option to display
+#         'searchbox.html',
+#     ]
+# }
+
 html_sidebars = {
-    '**': [
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
-    ]
+    "**": ["sidebar-nav-bs"]
 }
 
 

--- a/conf.py
+++ b/conf.py
@@ -97,6 +97,7 @@ html_theme_options = {
     ],
     "use_edit_page_button": True,
     "github_url": "https://github.com/dashpay/docs",
+    "announcement": "<p>Testing pydata theme for <a href='https://docs.dash.org'>docs.dash.org!</a></p>"
 }
 
 html_context = {

--- a/conf.py
+++ b/conf.py
@@ -99,7 +99,6 @@ html_theme_options = {
     ],
     "use_edit_page_button": True,
     "github_url": "https://github.com/dashpay/docs",
-    "announcement": "<p>Testing pydata theme for <a href='https://docs.dash.org'>docs.dash.org!</a></p>",
     "show_toc_level": 2,
     "show_nav_level": 2,
 }

--- a/index-network.rst
+++ b/index-network.rst
@@ -1,0 +1,12 @@
+Network
+=======
+
+.. toctree::
+
+  governance/index
+  masternodes/index
+  mining/index
+  developers/index
+  network/electrumx-server
+  marketing
+  legal

--- a/index-users.rst
+++ b/index-users.rst
@@ -1,0 +1,7 @@
+Users
+=====
+
+.. toctree::
+
+   wallets/index
+   earning-spending

--- a/index.rst
+++ b/index.rst
@@ -49,34 +49,43 @@ Contents
 ========
 
 .. toctree::
-   :maxdepth: 3
-   :caption: First Steps
-
-   introduction/about
-   introduction/features
-   introduction/how-to-buy
-   introduction/safety
-   introduction/information
-
-.. _user-docs:
+   introduction/index
 
 .. toctree::
-   :maxdepth: 3
-   :caption: Users
-
-   wallets/index
-   earning-spending
-
-.. _network-docs:
+   index-users
 
 .. toctree::
-   :maxdepth: 3
-   :caption: Network
+   index-network
 
-   governance/index.rst
-   masternodes/index
-   mining/index
-   developers/index
-   network/electrumx-server
-   marketing.rst
-   legal.rst
+.. .. toctree::
+..    :maxdepth: 3
+..    :caption: First Steps
+
+..    introduction/about
+..    introduction/features
+..    introduction/how-to-buy
+..    introduction/safety
+..    introduction/information
+
+.. .. _user-docs:
+
+.. .. toctree::
+..    :maxdepth: 3
+..    :caption: Users
+
+..    wallets/index
+..    earning-spending
+
+.. .. _network-docs:
+
+.. .. toctree::
+..    :maxdepth: 3
+..    :caption: Network
+
+..    governance/index.rst
+..    masternodes/index
+..    mining/index
+..    developers/index
+..    network/electrumx-server
+..    marketing.rst
+..    legal.rst

--- a/introduction/index.rst
+++ b/introduction/index.rst
@@ -1,0 +1,10 @@
+First Steps
+===========
+
+.. toctree::
+  
+  about
+  features
+  how-to-buy
+  safety
+  information

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pydata-sphinx-theme==0.12.0rc1
 sphinx==5.3.0
 sphinx-copybutton==0.5.0
 sphinx_rtd_theme==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydata-sphinx-theme==0.12.0rc1
+pydata-sphinx-theme==0.12.0
 sphinx==5.3.0
 sphinx-copybutton==0.5.0
 sphinx_rtd_theme==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pydata-sphinx-theme==0.12.0
 sphinx==5.3.0
 sphinx-copybutton==0.5.0
-sphinx_rtd_theme==1.1.1
 jinja2==3.0.0


### PR DESCRIPTION
Switches site theme to [Pydata](https://pydata-sphinx-theme.readthedocs.io/en/stable/index.html). Minor changes related to index files to make the 3 main sections (First Steps, Users, Network) show up in the header instead of all lower-level section links.