### PR TITLE
feat: add sidebar to main page with links to all 3 sets of docs

### DIFF
--- a/_templates/sidebar-main.html
+++ b/_templates/sidebar-main.html
@@ -1,0 +1,96 @@
+<div class="sidebar-start-items sidebar-primary__section">
+  <div class="sidebar-start-items__item">
+    <nav class="bd-links" id="bd-docs-nav" aria-label="Section navigation">
+      <p class="bd-links__title" role="heading" aria-level="1">
+        Navigation
+      </p>
+      <div class="bd-toc-item navbar-nav">
+        <p aria-level="2" class="caption" role="heading"><span class="caption-text">User Docs</span></p>
+        <ul class="nav bd-sidenav">
+          <li class="toctree-l1 has-children"><a class="reference internal" href="docs/user/index.html">First
+              Steps</a><input class="toctree-checkbox" id="toctree-checkbox-1" name="toctree-checkbox-1"
+              type="checkbox" /><label class="toctree-toggle" for="toctree-checkbox-1"><i
+                class="fa-solid fa-chevron-down"></i></label>
+            <ul>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/introduction/about.html">What is
+                  Dash?</a></li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/introduction/features.html">Features</a></li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/introduction/how-to-buy.html">How To Buy</a>
+              </li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/introduction/safety.html">Safety</a></li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/introduction/information.html">Links and
+                  Information</a></li>
+            </ul>
+          </li>
+
+          <li class="toctree-l1 has-children"><a class="reference internal"
+              href="docs/user/wallets/index.html">Users</a><input class="toctree-checkbox" id="toctree-checkbox-2"
+              name="toctree-checkbox-2" type="checkbox" /><label class="toctree-toggle" for="toctree-checkbox-2"><i
+                class="fa-solid fa-chevron-down"></i></label>
+            <ul>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/wallets/index.html">Wallets</a></li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/earning-spending.html">Earning and
+                  Spending</a></li>
+            </ul>
+          </li>
+
+          <li class="toctree-l1 has-children"><a class="reference internal"
+              href="docs/user/governance/index.html">Network</a><input class="toctree-checkbox" id="toctree-checkbox-13"
+              name="toctree-checkbox-13" type="checkbox" /><label class="toctree-toggle" for="toctree-checkbox-13"><i
+                class="fa-solid fa-chevron-down"></i></label>
+            <ul>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/wallets/index.html">Governance</a>
+              </li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/wallets/index.html">Masternodes</a>
+              </li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/wallets/index.html">Mining</a></li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/wallets/index.html">Developers</a>
+              </li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/wallets/index.html">ElectrumX
+                  Server</a></li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/wallets/index.html">Marketing</a>
+              </li>
+              <li class="toctree-l2"><a class="reference internal" href="docs/user/wallets/index.html">Legal</a></li>
+            </ul>
+          </li>
+        </ul>
+
+        <!-- Core docs (external site) -->
+        <p aria-level="2" class="caption" role="heading"><span class="caption-text">Core Docs</span></p>
+        <ul class="nav bd-sidenav">
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://dashcore.readme.io/docs/core-ref-introduction">Blockchain Reference</a></li>
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://dashcore.readme.io/docs/core-api-ref-remote-procedure-calls">API Reference</a>
+          </li>
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://dashcore.readme.io/docs/core-guide-introduction">Core Guides</a></li>
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://dashcore.readme.io/docs/core-examples-introduction">Core Examples</a></li>
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://dashcore.readme.io/docs/dash-core-wallet-arguments-and-commands">Dash Core Wallet</a></li>
+          </li>
+        </ul>
+
+        <!-- Platform docs (external site) -->
+        <p aria-level="2" class="caption" role="heading"><span class="caption-text">Platform Docs</span></p>
+        <ul class="nav bd-sidenav">
+
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://dashplatform.readme.io/docs/introduction-what-is-dash-platform">Introduction</a></li>
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://dashplatform.readme.io/docs/tutorials-introduction">Tutorials</a>
+          </li>
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://dashplatform.readme.io/docs/explanation-dapi">Explanations</a></li>
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://dashplatform.readme.io/docs/reference-dapi-endpoints">Reference</a></li>
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://dashplatform.readme.io/docs/platform-protocol-reference-overview">Platform Protocol</a></li>
+          </li>
+
+        </ul>
+      </div>
+    </nav>
+  </div>
+</div>

--- a/conf.py
+++ b/conf.py
@@ -177,6 +177,7 @@ html_css_files = [
 # }
 
 html_sidebars = {
+    "index": ["sidebar-main.html"],
     "**": ["sidebar-nav-bs"]
 }
 

--- a/index.rst
+++ b/index.rst
@@ -1,4 +1,4 @@
-:html_theme.sidebar_secondary.remove:
+.. :html_theme.sidebar_secondary.remove:
 
 .. meta::
    :description: The Dash Documentation offers information and guides on Dash, the open source peer-to-peer cryptocurrency with a strong focus on the payments industry. 


### PR DESCRIPTION
Based on some feedback this adds a custom sidebar page (unfortunately not auto-created) to be shown on the main page. See example here: https://dash-docs--179.org.readthedocs.build/en/179/.