### PR TITLE
fix: language selector fix

### DIFF
--- a/_static/js/lang.js
+++ b/_static/js/lang.js
@@ -32,7 +32,15 @@ $(function(){
 		} else if (newlang == "zh-TW") {
 			newlang = "zh_TW";
 		}
-		pageURL = pageURL.replace("https://docs.dash.org/" + DOCUMENTATION_OPTIONS['LANGUAGE'], "");
+		
+		var currentlang = DOCUMENTATION_OPTIONS['LANGUAGE'];
+		if (currentlang == "zh-CN") {
+			currentlang = "zh_CN";
+		} else if (currentlang == "zh-TW") {
+			currentlang = "zh_TW";
+		}
+
+		pageURL = pageURL.replace("https://docs.dash.org/" + currentlang, "");
 		window.location.href = "https://docs.dash.org/" + newlang + pageURL;
 	});
 });

--- a/_static/js/lang.js
+++ b/_static/js/lang.js
@@ -26,13 +26,13 @@ $(document).ready(function() {
 $(function(){
 	$("#langselect").on('change', function() {
 		var pageURL = $(location).attr("href");
-		var lang = $('#langselect').val();
-		if (lang == "zh-CN") {
-			lang = "zh_CN";
-		} else if (lang == "zh-TW") {
-			lang = "zh_TW";
+		var newlang = $('#langselect').val();
+		if (newlang == "zh-CN") {
+			newlang = "zh_CN";
+		} else if (newlang == "zh-TW") {
+			newlang = "zh_TW";
 		}
 		pageURL = pageURL.replace("https://docs.dash.org/" + DOCUMENTATION_OPTIONS['LANGUAGE'], "");
-		window.location.href = "https://docs.dash.org/" + lang + pageURL;
+		window.location.href = "https://docs.dash.org/" + newlang + pageURL;
 	});
 });

--- a/_static/js/lang.js
+++ b/_static/js/lang.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 	/* Select current language */
 	$('#langselect').val(DOCUMENTATION_OPTIONS['LANGUAGE']);
-	
+	console.log(`lang: ${DOCUMENTATION_OPTIONS['LANGUAGE']}`)
 	/* Set alternate links 
 	var langs = [ "de", "en", "es", "fr", "pt", "vi", "el", "ru", "ko", "ja", "zh-Hans", "zh-Hant", "ar", "x-default" ];
 	var pageURL = $(location).attr("href");
@@ -26,7 +26,9 @@ $(document).ready(function() {
 $(function(){
 	$("#langselect").on('change', function() {
 		var pageURL = $(location).attr("href");
+		console.log(`pageURL: ${pageURL}`)
 		pageURL = pageURL.replace("https://docs.dash.org/" + DOCUMENTATION_OPTIONS['LANGUAGE'], "");
+		console.log(`pageURL: ${pageURL}`)
 		window.location.href = "https://docs.dash.org/" + $('#langselect').val() + pageURL;
 	});
 });

--- a/_static/js/lang.js
+++ b/_static/js/lang.js
@@ -26,21 +26,21 @@ $(document).ready(function() {
 $(function(){
 	$("#langselect").on('change', function() {
 		var pageURL = $(location).attr("href");
-		var newlang = $('#langselect').val();
-		if (newlang == "zh-CN") {
-			newlang = "zh_CN";
-		} else if (newlang == "zh-TW") {
-			newlang = "zh_TW";
+		var newLang = $('#langselect').val();
+		if (newLang == "zh-CN") {
+			newLang = "zh_CN";
+		} else if (newLang == "zh-TW") {
+			newLang = "zh_TW";
 		}
 		
-		var currentlang = DOCUMENTATION_OPTIONS['LANGUAGE'];
-		if (currentlang == "zh-CN") {
-			currentlang = "zh_CN";
-		} else if (currentlang == "zh-TW") {
-			currentlang = "zh_TW";
+		var currentLang = DOCUMENTATION_OPTIONS['LANGUAGE'];
+		if (currentLang == "zh-CN") {
+			currentLang = "zh_CN";
+		} else if (currentLang == "zh-TW") {
+			currentLang = "zh_TW";
 		}
 
-		pageURL = pageURL.replace("https://docs.dash.org/" + currentlang, "");
-		window.location.href = "https://docs.dash.org/" + newlang + pageURL;
+		pageURL = pageURL.replace("https://docs.dash.org/" + currentLang, "");
+		window.location.href = "https://docs.dash.org/" + newLang + pageURL;
 	});
 });

--- a/_static/js/lang.js
+++ b/_static/js/lang.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 	/* Select current language */
 	$('#langselect').val(DOCUMENTATION_OPTIONS['LANGUAGE']);
-	console.log(`lang: ${DOCUMENTATION_OPTIONS['LANGUAGE']}`)
+	
 	/* Set alternate links 
 	var langs = [ "de", "en", "es", "fr", "pt", "vi", "el", "ru", "ko", "ja", "zh-Hans", "zh-Hant", "ar", "x-default" ];
 	var pageURL = $(location).attr("href");
@@ -26,9 +26,13 @@ $(document).ready(function() {
 $(function(){
 	$("#langselect").on('change', function() {
 		var pageURL = $(location).attr("href");
-		console.log(`pageURL: ${pageURL}`)
+		var lang = $('#langselect').val();
+		if (lang == "zh-CN") {
+			lang = "zh_CN";
+		} else if (lang == "zh-TW") {
+			lang = "zh_TW";
+		}
 		pageURL = pageURL.replace("https://docs.dash.org/" + DOCUMENTATION_OPTIONS['LANGUAGE'], "");
-		console.log(`pageURL: ${pageURL}`)
-		window.location.href = "https://docs.dash.org/" + $('#langselect').val() + pageURL;
+		window.location.href = "https://docs.dash.org/" + lang + pageURL;
 	});
 });

--- a/_templates/languages.html
+++ b/_templates/languages.html
@@ -11,7 +11,7 @@
   <option value="ru">Русский</option>
   <option value="ko">한국어</option>
   <option value="ja">日本語</option>
-  <option value="zh_CN">简体中文</option>
-  <option value="zh_TW">繁体中文</option>
+  <option value="zh-CN">简体中文</option>
+  <option value="zh-TW">繁体中文</option>
   <option value="ar">العربية</option>
 </select>


### PR DESCRIPTION
The language selector is currently broken for several languages. There is a difference between how `DOCUMENTATION_OPTIONS['LANGUAGE']` displays these languages (e.g. `zh-CN`) and the actual URL format (e.g. `zh_CN`). At some point in the past (version 0.17.0 of the docs, for example), there wasn't a discrepancy so it's likely that recent updates to sphinx/rtd dependencies broke this. Anyway, this is probably not the prettiest way to fix this, but it works in my testing so that the selector shows the selected language and also allows switching properly to other languages.