### PR TITLE
style: change image to figure

### DIFF
--- a/docs/user/wallets/dashcore/installation-macos.rst
+++ b/docs/user/wallets/dashcore/installation-macos.rst
@@ -95,7 +95,7 @@ menu, then click **Open** again in the dialog box. The app is saved as
 an exception to your security settings, and you can open it in the
 future by double-clicking it just as you can any registered app.
 
-.. image:: img/macos/112414895.png
+.. figure:: img/macos/112414895.png
    :width: 280px
 
 .. figure:: img/macos/112414905.png


### PR DESCRIPTION
In cases where there are sequential images and the first one uses the image directive and the second uses the figure directive, the image will be left aligned by default and the figure center aligned. Changing the first one to a figure also makes them align consistently.

Relates to #204 

Preview of fixed image: https://dash-docs--203.org.readthedocs.build/en/203/docs/user/wallets/dashcore/installation-macos.html#running-dash-core-for-the-first-time