### PR TITLE
Revert "adding PDF type"

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,10 +10,6 @@ build:
    tools:
       python: "3.10"
 
-# Building PDF
-formats:
-  - pdf
-
 python:
    install:
       - requirements: requirements.txt


### PR DESCRIPTION
Reverts dashpay/docs#210 due to PDF build failure causing the entire build to fail

![image](https://user-images.githubusercontent.com/8145677/225419830-d4c7d177-f2f0-49a5-8f95-3242b3c177f4.png)
