### PR TITLE
fix: replace U+0421 with "C"

### DIFF
--- a/docs/user/developers/integration.rst
+++ b/docs/user/developers/integration.rst
@@ -353,7 +353,7 @@ Blockmove
 
 https://blockmove.io
 
-Сryptocurrency wallet, merchant & API provider. Blockmove is a simple
+Cryptocurrency wallet, merchant & API provider. Blockmove is a simple
 and easy way to start accepting payments in cryptocurrency.
 
 - Features: Non-custodial wallet, HD Wallet, High anonymity, Low fees. 


### PR DESCRIPTION
Pandoc PDF conversion failed because there was a "С" where it looks like a "C" should be :man_facepalming: 