### PR TITLE
ci: add preview url to end of PR descriptions

### DIFF
--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-22.04
     steps:
       - name: edit-pull-request-description
         uses: Jerome1337/comment-pull-request@v1.0.4

--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -1,4 +1,7 @@
 name: Add preview URL to PR description
+on:
+  pull_request:
+    types: [opened]
 
 jobs:
   build:

--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -1,10 +1,14 @@
-- name: edit-pull-request-description
-  uses: Jerome1337/comment-pull-request@v1.0.4
+name Add preview URL to PR description
 
-  env:
-    GITHUB_TOKEN: ${{ github.token }}
-  with:
-    description-message: |
-      ----
-      🛠 Preview build: https://dash-docs--${{github.event.pull_request.number}}.org.readthedocs.build/en/${{github.event.pull_request.number}}/
-      
+jobs:
+  build:
+    steps:
+      - name: edit-pull-request-description
+        uses: Jerome1337/comment-pull-request@v1.0.4
+
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          description-message: |
+            ----
+            🛠 Preview build: https://dash-docs--${{github.event.pull_request.number}}.org.readthedocs.build/en/${{github.event.pull_request.number}}/

--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -1,0 +1,10 @@
+- name: edit-pull-request-description
+  uses: Jerome1337/comment-pull-request@v1.0.4
+
+  env:
+    GITHUB_TOKEN: ${{ github.token }}
+  with:
+    description-message: |
+      ----
+      🛠 Preview build: https://dash-docs--${{github.event.pull_request.number}}.org.readthedocs.build/en/${{github.event.pull_request.number}}/
+      

--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -1,7 +1,7 @@
 name: Add preview URL to PR description
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -1,4 +1,4 @@
-name Add preview URL to PR description
+name: Add preview URL to PR description
 
 jobs:
   build:

--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -1,7 +1,7 @@
 name: Add preview URL to PR description
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened]
 
 jobs:
   build:
@@ -14,5 +14,5 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           description-message: |
-            ----
-            🛠 Preview build: https://dash-docs--${{github.event.pull_request.number}}.org.readthedocs.build/en/${{github.event.pull_request.number}}/
+            
+            Preview build: https://dash-docs--${{github.event.pull_request.number}}.org.readthedocs.build/en/${{github.event.pull_request.number}}/


### PR DESCRIPTION
This PR adds a GitHub Action to automatically append a link to the RTD PR build at the end of the PR description. Tested over here: https://github.com/thephez/dash-user-docs/pull/26. Hopefully it will work the same way here :crossed_fingers: 