### PR TITLE
build: pin Babel version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+Babel==2.11.0
 myst-parser==0.18.1
 pydata-sphinx-theme==0.12.0
 sphinx==5.3.0


### PR DESCRIPTION
The latest version of Babel has an issue that causes an error when "make html" is run in some cases. Installing pytz seems to fix it, but this issue makes it seem like that dependency is undesirable: https://github.com/python-babel/babel/issues/716.

Pinning to Babel 2.11.0 for now avoids local build issues.