### PR TITLE
docs: 19.0.0 binary updates

### DIFF
--- a/docs/user/developers/insight.rst
+++ b/docs/user/developers/insight.rst
@@ -32,7 +32,7 @@ dependencies::
 Download and extract the latest version of Dash Core::
 
   cd ~
-  wget https://github.com/dashpay/dash/releases/download/v18.2.2/dashcore-18.2.2-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz
   tar -xvzf dashcore-18.2.2-x86_64-linux-gnu.tar.gz
   rm dashcore-18.2.2-x86_64-linux-gnu.tar.gz
 

--- a/docs/user/developers/insight.rst
+++ b/docs/user/developers/insight.rst
@@ -33,8 +33,8 @@ Download and extract the latest version of Dash Core::
 
   cd ~
   wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz
-  tar -xvzf dashcore-18.2.2-x86_64-linux-gnu.tar.gz
-  rm dashcore-18.2.2-x86_64-linux-gnu.tar.gz
+  tar -xvzf dashcore-19.0.0-x86_64-linux-gnu.tar.gz
+  rm dashcore-19.0.0-x86_64-linux-gnu.tar.gz
 
 Install `Dashcore Node <https://github.com/dashevo/dashcore-node>`_ and
 create your configuration::

--- a/docs/user/developers/insight.rst
+++ b/docs/user/developers/insight.rst
@@ -55,7 +55,7 @@ Change paths in the configuration file as follows::
   nano dashcore-node.json
 
 - Change the value of ``datadir`` to ``../../.dashcore``
-- Change the value of ``exec`` to ``../../dashcore-18.2.2/bin/dashd``
+- Change the value of ``exec`` to ``../../dashcore-19.0.0/bin/dashd``
 - **Optionally** change the value of ``network`` to ``testnet`` if you 
   want to run Insight on testnet
 

--- a/docs/user/masternodes/maintenance.rst
+++ b/docs/user/masternodes/maintenance.rst
@@ -69,8 +69,8 @@ following keys:
 Extract the compressed archive and copy the new files to the directory::
 
   tar xfv dashcore-19.0.0-x86_64-linux-gnu.tar.gz
-  cp -f dashcore-18.2.2/bin/dashd ~/.dashcore/
-  cp -f dashcore-18.2.2/bin/dash-cli ~/.dashcore/
+  cp -f dashcore-19.0.0/bin/dashd ~/.dashcore/
+  cp -f dashcore-19.0.0/bin/dash-cli ~/.dashcore/
 
 Restart Dash::
 

--- a/docs/user/masternodes/maintenance.rst
+++ b/docs/user/masternodes/maintenance.rst
@@ -47,7 +47,7 @@ enter the following command, pasting in the address to the latest
 version of Dash Core by right clicking or pressing **Ctrl + V**::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v18.2.2/dashcore-18.2.2-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -63,7 +63,7 @@ following keys:
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v18.2.2/dashcore-18.2.2-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz.asc
   gpg --verify dashcore-18.2.2-x86_64-linux-gnu.tar.gz.asc
 
 Extract the compressed archive and copy the new files to the directory::

--- a/docs/user/masternodes/maintenance.rst
+++ b/docs/user/masternodes/maintenance.rst
@@ -64,11 +64,11 @@ following keys:
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
   wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-18.2.2-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-19.0.0-x86_64-linux-gnu.tar.gz.asc
 
 Extract the compressed archive and copy the new files to the directory::
 
-  tar xfv dashcore-18.2.2-x86_64-linux-gnu.tar.gz
+  tar xfv dashcore-19.0.0-x86_64-linux-gnu.tar.gz
   cp -f dashcore-18.2.2/bin/dashd ~/.dashcore/
   cp -f dashcore-18.2.2/bin/dash-cli ~/.dashcore/
 

--- a/docs/user/masternodes/setup-testnet.rst
+++ b/docs/user/masternodes/setup-testnet.rst
@@ -639,7 +639,7 @@ and communication relating to the base blockchain. Download Dash Core as
 follows::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v18.2.2/dashcore-18.2.2-$(uname -m)-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-$(uname -m)-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -655,7 +655,7 @@ following keys:
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v18.2.2/dashcore-18.2.2-$(uname -m)-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-$(uname -m)-linux-gnu.tar.gz.asc
   gpg --verify dashcore-18.2.2-$(uname -m)-linux-gnu.tar.gz.asc
 
 Extract the compressed archive and copy the necessary files to the

--- a/docs/user/masternodes/setup-testnet.rst
+++ b/docs/user/masternodes/setup-testnet.rst
@@ -662,7 +662,7 @@ Extract the compressed archive and copy the necessary files to the
 directory::
 
   tar xfv dashcore-19.0.0-$(uname -m)-linux-gnu.tar.gz
-  sudo install -t /usr/local/bin dashcore-18.2.2/bin/*
+  sudo install -t /usr/local/bin dashcore-19.0.0/bin/*
 
 Create a working directory for Dash Core::
 

--- a/docs/user/masternodes/setup-testnet.rst
+++ b/docs/user/masternodes/setup-testnet.rst
@@ -656,12 +656,12 @@ following keys:
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
   wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-$(uname -m)-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-18.2.2-$(uname -m)-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-19.0.0-$(uname -m)-linux-gnu.tar.gz.asc
 
 Extract the compressed archive and copy the necessary files to the
 directory::
 
-  tar xfv dashcore-18.2.2-$(uname -m)-linux-gnu.tar.gz
+  tar xfv dashcore-19.0.0-$(uname -m)-linux-gnu.tar.gz
   sudo install -t /usr/local/bin dashcore-18.2.2/bin/*
 
 Create a working directory for Dash Core::

--- a/docs/user/masternodes/setup.rst
+++ b/docs/user/masternodes/setup.rst
@@ -233,7 +233,7 @@ address to the latest version of Dash Core by right clicking or pressing
 **Ctrl + V**::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v18.2.2/dashcore-18.2.2-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -249,7 +249,7 @@ following keys:
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v18.2.2/dashcore-18.2.2-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz.asc
   gpg --verify dashcore-18.2.2-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive and

--- a/docs/user/masternodes/setup.rst
+++ b/docs/user/masternodes/setup.rst
@@ -257,8 +257,8 @@ copy the necessary files to the directory::
 
   mkdir ~/.dashcore
   tar xfv dashcore-19.0.0-x86_64-linux-gnu.tar.gz
-  cp -f dashcore-18.2.2/bin/dashd ~/.dashcore/
-  cp -f dashcore-18.2.2/bin/dash-cli ~/.dashcore/
+  cp -f dashcore-19.0.0/bin/dashd ~/.dashcore/
+  cp -f dashcore-19.0.0/bin/dash-cli ~/.dashcore/
 
 Create a configuration file using the following command::
 

--- a/docs/user/masternodes/setup.rst
+++ b/docs/user/masternodes/setup.rst
@@ -250,13 +250,13 @@ following keys:
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
   wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-18.2.2-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-19.0.0-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive and
 copy the necessary files to the directory::
 
   mkdir ~/.dashcore
-  tar xfv dashcore-18.2.2-x86_64-linux-gnu.tar.gz
+  tar xfv dashcore-19.0.0-x86_64-linux-gnu.tar.gz
   cp -f dashcore-18.2.2/bin/dashd ~/.dashcore/
   cp -f dashcore-18.2.2/bin/dash-cli ~/.dashcore/
 

--- a/docs/user/mining/p2pool.rst
+++ b/docs/user/mining/p2pool.rst
@@ -129,19 +129,19 @@ following keys:
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
   wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-18.2.2-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-19.0.0-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive,
 copy the necessary files to the directory and set them as executable::
 
   mkdir ~/.dashcore
-  tar xfvz dashcore-18.2.2-x86_64-linux-gnu.tar.gz
+  tar xfvz dashcore-19.0.0-x86_64-linux-gnu.tar.gz
   cp dashcore-18.2.2/bin/dashd .dashcore/
   cp dashcore-18.2.2/bin/dash-cli .dashcore/
 
 Clean up unneeded files::
 
-  rm dashcore-18.2.2-x86_64-linux-gnu.tar.gz
+  rm dashcore-19.0.0-x86_64-linux-gnu.tar.gz
   rm -r dashcore-18.2.2/
 
 Create a configuration file using the following command::

--- a/docs/user/mining/p2pool.rst
+++ b/docs/user/mining/p2pool.rst
@@ -112,7 +112,7 @@ address to the latest version of Dash Core by right clicking or pressing
 **Ctrl + V**::
 
   cd ~
-  wget https://github.com/dashpay/dash/releases/download/v18.2.2/dashcore-18.2.2-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -128,7 +128,7 @@ following keys:
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v18.2.2/dashcore-18.2.2-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v19.0.0/dashcore-19.0.0-x86_64-linux-gnu.tar.gz.asc
   gpg --verify dashcore-18.2.2-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive,

--- a/docs/user/mining/p2pool.rst
+++ b/docs/user/mining/p2pool.rst
@@ -136,13 +136,13 @@ copy the necessary files to the directory and set them as executable::
 
   mkdir ~/.dashcore
   tar xfvz dashcore-19.0.0-x86_64-linux-gnu.tar.gz
-  cp dashcore-18.2.2/bin/dashd .dashcore/
-  cp dashcore-18.2.2/bin/dash-cli .dashcore/
+  cp dashcore-19.0.0/bin/dashd .dashcore/
+  cp dashcore-19.0.0/bin/dash-cli .dashcore/
 
 Clean up unneeded files::
 
   rm dashcore-19.0.0-x86_64-linux-gnu.tar.gz
-  rm -r dashcore-18.2.2/
+  rm -r dashcore-19.0.0/
 
 Create a configuration file using the following command::
 

--- a/docs/user/wallets/dashcore/installation-linux.rst
+++ b/docs/user/wallets/dashcore/installation-linux.rst
@@ -61,7 +61,7 @@ download as follows::
 
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import  
-  gpg --verify dashcore-18.2.2-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-19.0.0-x86_64-linux-gnu.tar.gz.asc
 
 .. figure:: img/linux/setup-linux-gpg.png
    :width: 400px
@@ -82,7 +82,7 @@ we will extract the executable file with a graphical user interface
 
 Extract Dash Core as follows::
 
-  tar xzf dashcore-18.2.2-x86_64-linux-gnu.tar.gz
+  tar xzf dashcore-19.0.0-x86_64-linux-gnu.tar.gz
 
 This will create a folder named ``dashcore-18.2.2`` in the current working
 directory. We will now install the executable binaries to

--- a/docs/user/wallets/dashcore/installation-linux.rst
+++ b/docs/user/wallets/dashcore/installation-linux.rst
@@ -84,11 +84,11 @@ Extract Dash Core as follows::
 
   tar xzf dashcore-19.0.0-x86_64-linux-gnu.tar.gz
 
-This will create a folder named ``dashcore-18.2.2`` in the current working
+This will create a folder named ``dashcore-19.0.0`` in the current working
 directory. We will now install the executable binaries to
 ``/usr/local/bin`` using the ``install`` command::
 
-  sudo install -m 0755 -o root -g root -t /usr/local/bin dashcore-18.2.2/bin/*
+  sudo install -m 0755 -o root -g root -t /usr/local/bin dashcore-19.0.0/bin/*
 
 Start Dash Core from the terminal with the following command::
   

--- a/docs/user/wallets/dashcore/installation-macos.rst
+++ b/docs/user/wallets/dashcore/installation-macos.rst
@@ -52,7 +52,7 @@ download as follows::
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  gpg --verify dashcore-18.2.2-osx.dmg.asc
+  gpg --verify dashcore-19.0.0-osx.dmg.asc
 
 
 .. figure:: img/linux/setup-linux-gpg.png

--- a/docs/user/wallets/dashcore/installation-windows.rst
+++ b/docs/user/wallets/dashcore/installation-windows.rst
@@ -75,7 +75,7 @@ Import the key files and verify the Key-ID matches the ID above.
 
 Skip any requests to certify the certificate with your own key. Next,
 click **Decrypt/Verify...** and select the detached signature file named
-``dashcore-18.2.2-win64-setup.exe.asc`` in the same folder as the
+``dashcore-19.0.0-win64-setup.exe.asc`` in the same folder as the
 downloaded installer.
 
 .. figure:: img/windows/setup-windows-kleopatra-verify.png
@@ -84,8 +84,8 @@ downloaded installer.
    Selecting the signature file for verification
 
 If you see the first line of the message reads ``Verified
-dashcore-18.2.2-win64-setup.exe with
-dashcore-18.2.2-win64-setup.exe.asc`` then you have an authentic copy
+dashcore-19.0.0-win64-setup.exe with
+dashcore-19.0.0-win64-setup.exe.asc`` then you have an authentic copy
 of Dash Core for Windows.
 
 .. figure:: img/windows/setup-windows-kleopatra-verified.png


### PR DESCRIPTION
Update download / command references to use v19 instead of v18

Closes: #193 