### PR TITLE
fix: update masternode outputs response format

### DIFF
--- a/docs/user/masternodes/setup-hpmn.rst
+++ b/docs/user/masternodes/setup-hpmn.rst
@@ -453,7 +453,7 @@ enter the following command::
 This should return a string of characters similar to the following::
 
   {
-  "16347a28f4e5edf39f4dceac60e2327931a25fdee1fb4b94b63eeacf0d5879e3" : "1",
+  "16347a28f4e5edf39f4dceac60e2327931a25fdee1fb4b94b63eeacf0d5879e3-1",
   }
 
 The first long string is your ``collateralHash``, while the last number is the

--- a/docs/user/masternodes/setup-testnet.rst
+++ b/docs/user/masternodes/setup-testnet.rst
@@ -381,7 +381,7 @@ transaction, you now need to find the txid of the transaction. Click
 This should return a string of characters similar to the following::
 
   {
-  "16347a28f4e5edf39f4dceac60e2327931a25fdee1fb4b94b63eeacf0d5879e3" : "1",
+  "16347a28f4e5edf39f4dceac60e2327931a25fdee1fb4b94b63eeacf0d5879e3-1",
   }
 
 The first long string is your ``collateralHash``, while the last number

--- a/docs/user/masternodes/setup.rst
+++ b/docs/user/masternodes/setup.rst
@@ -450,7 +450,7 @@ transaction, you now need to find the txid of the transaction. Click
 This should return a string of characters similar to the following::
 
   {
-  "16347a28f4e5edf39f4dceac60e2327931a25fdee1fb4b94b63eeacf0d5879e3" : "1",
+  "16347a28f4e5edf39f4dceac60e2327931a25fdee1fb4b94b63eeacf0d5879e3-1",
   }
 
 The first long string is your ``collateralHash``, while the last number


### PR DESCRIPTION
The `masternode outputs` RPC response format changed in the previous release. This updates the docs to show the correct format.