### PR TITLE
docs: switch header and card links to docs-core site

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -136,7 +136,7 @@ html_theme = "pydata_sphinx_theme"
 #
 html_theme_options = {
     "external_links": [
-        {"name": "Core docs", "url": "https://dashcore.readme.io/"},
+        {"name": "Core docs", "url": "https://docs.dash.org/projects/core/en/stable/docs/index.html"},
         {"name": "Platform docs", "url": "https://dashplatform.readme.io"},
         {"name": "Dash.org", "url": "https://www.dash.org"},
         {"name": "Forum", "url": "https://www.dash.org/forum"},

--- a/index.rst
+++ b/index.rst
@@ -46,13 +46,13 @@ learning about :ref:`safety <safety>` or joining one of the many
 
     .. grid-item-card:: ⚙ Core Docs
         :margin: 2 2 auto auto
-        :link-type: url
-        :link: https://docs.dash.org/projects/core/en/stable/docs/index.html
+        :link-type: ref
+        :link: core:core-index
         
         Find technical details about the Dash Core blockchain, along with protocol and API reference material.
         
         +++
-        `Click to begin <https://docs.dash.org/projects/core/en/stable/docs/index.html>`__
+        :ref:`Click to begin <core:core-index>`
 
     .. grid-item-card:: 🚀 Platform Docs
          :margin: 2 2 auto auto

--- a/index.rst
+++ b/index.rst
@@ -47,12 +47,12 @@ learning about :ref:`safety <safety>` or joining one of the many
     .. grid-item-card:: ⚙ Core Docs
         :margin: 2 2 auto auto
         :link-type: url
-        :link: https://dashcore.readme.io
+        :link: https://docs.dash.org/projects/core/en/stable/docs/index.html
         
         Find technical details about the Dash Core blockchain, along with protocol and API reference material.
         
         +++
-        `Click to begin <https://dashcore.readme.io>`__
+        `Click to begin <https://docs.dash.org/projects/core/en/stable/docs/index.html>`__
 
     .. grid-item-card:: 🚀 Platform Docs
          :margin: 2 2 auto auto


### PR DESCRIPTION
Dependent on #253