### PR TITLE
ci: update preview-url action

### DIFF
--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -1,6 +1,6 @@
 name: Add preview URL to PR description
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:

--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -2,6 +2,11 @@ name: Add preview URL to PR description
 on:
   pull_request_target:
     types: [opened]
+    paths:
+      - '**.md'
+      - '**.png'
+      - '**.rst'
+      - '**.svg'
 
 jobs:
   build:


### PR DESCRIPTION
Check if switching to `pull_request_target` will address the issues discussed in #226. Also, only run the action for PRs where doc-related files are modified.