### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 _build
 *.sublime-project
 *.sublime-workspace
-.DS_Store
+**/.DS_Store
 .vscode
 transifex/.env


### PR DESCRIPTION
Try to make sure no `.DS_Store` files are added from _any_ directory. This [shouldn't be necessary](https://stackoverflow.com/questions/34846807/git-status-still-shows-ds-store-file-even-though-it-is-in-the-ignore-list), but :man_shrugging: 