### PR TITLE
chore: transifex api migration

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,417 +1,417 @@
 [main]
 host = https://www.transifex.com
 
-[dash-docs.index]
-file_filter = locale/<lang>/LC_MESSAGES/index.po
-source_file = locale/pot/index.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--earning-spending]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/earning-spending.po
-source_file = locale/pot/docs/user/earning-spending.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/index.po
-source_file = locale/pot/docs/user/index.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--legal]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/legal.po
-source_file = locale/pot/docs/user/legal.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--marketing]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/marketing.po
-source_file = locale/pot/docs/user/marketing.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--developers--compiling]
+[o:dash:p:dash-docs:r:docs--user--developers--compiling]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/compiling.po
 source_file = locale/pot/docs/user/developers/compiling.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--developers--index]
+[o:dash:p:dash-docs:r:docs--user--developers--index]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/index.po
 source_file = locale/pot/docs/user/developers/index.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--developers--insight]
+[o:dash:p:dash-docs:r:docs--user--developers--insight]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/insight.po
 source_file = locale/pot/docs/user/developers/insight.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--developers--integration]
+[o:dash:p:dash-docs:r:docs--user--developers--integration]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/integration.po
 source_file = locale/pot/docs/user/developers/integration.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--developers--testnet]
+[o:dash:p:dash-docs:r:docs--user--developers--testnet]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/testnet.po
 source_file = locale/pot/docs/user/developers/testnet.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--developers--translating]
+[o:dash:p:dash-docs:r:docs--user--developers--translating]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/translating.po
 source_file = locale/pot/docs/user/developers/translating.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--governance--eight-steps]
+[o:dash:p:dash-docs:r:docs--user--earning-spending]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/earning-spending.po
+source_file = locale/pot/docs/user/earning-spending.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--governance--eight-steps]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/governance/eight-steps.po
 source_file = locale/pot/docs/user/governance/eight-steps.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--governance--index]
+[o:dash:p:dash-docs:r:docs--user--governance--index]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/governance/index.po
 source_file = locale/pot/docs/user/governance/index.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--governance--understanding]
+[o:dash:p:dash-docs:r:docs--user--governance--understanding]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/governance/understanding.po
 source_file = locale/pot/docs/user/governance/understanding.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--governance--using]
+[o:dash:p:dash-docs:r:docs--user--governance--using]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/governance/using.po
 source_file = locale/pot/docs/user/governance/using.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--introduction--about]
+[o:dash:p:dash-docs:r:docs--user--index]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/index.po
+source_file = locale/pot/docs/user/index.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--introduction--about]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/introduction/about.po
 source_file = locale/pot/docs/user/introduction/about.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--introduction--features]
+[o:dash:p:dash-docs:r:docs--user--introduction--features]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/introduction/features.po
 source_file = locale/pot/docs/user/introduction/features.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--introduction--how-to-buy]
+[o:dash:p:dash-docs:r:docs--user--introduction--how-to-buy]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/introduction/how-to-buy.po
 source_file = locale/pot/docs/user/introduction/how-to-buy.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--introduction--information]
+[o:dash:p:dash-docs:r:docs--user--introduction--information]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/introduction/information.po
 source_file = locale/pot/docs/user/introduction/information.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--introduction--safety]
+[o:dash:p:dash-docs:r:docs--user--introduction--safety]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/introduction/safety.po
 source_file = locale/pot/docs/user/introduction/safety.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--masternodes--advanced]
+[o:dash:p:dash-docs:r:docs--user--legal]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/legal.po
+source_file = locale/pot/docs/user/legal.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--marketing]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/marketing.po
+source_file = locale/pot/docs/user/marketing.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--masternodes--advanced]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/advanced.po
 source_file = locale/pot/docs/user/masternodes/advanced.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--masternodes--hosting]
+[o:dash:p:dash-docs:r:docs--user--masternodes--hosting]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/hosting.po
 source_file = locale/pot/docs/user/masternodes/hosting.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--masternodes--index]
+[o:dash:p:dash-docs:r:docs--user--masternodes--index]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/index.po
 source_file = locale/pot/docs/user/masternodes/index.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--masternodes--maintenance]
+[o:dash:p:dash-docs:r:docs--user--masternodes--maintenance]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/maintenance.po
 source_file = locale/pot/docs/user/masternodes/maintenance.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--masternodes--setup-testnet]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/setup-testnet.po
-source_file = locale/pot/docs/user/masternodes/setup-testnet.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--masternodes--setup]
+[o:dash:p:dash-docs:r:docs--user--masternodes--setup]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/setup.po
 source_file = locale/pot/docs/user/masternodes/setup.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--masternodes--understanding]
+[o:dash:p:dash-docs:r:docs--user--masternodes--setup-testnet]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/setup-testnet.po
+source_file = locale/pot/docs/user/masternodes/setup-testnet.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--masternodes--understanding]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/understanding.po
 source_file = locale/pot/docs/user/masternodes/understanding.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--mining--index]
+[o:dash:p:dash-docs:r:docs--user--mining--index]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/mining/index.po
 source_file = locale/pot/docs/user/mining/index.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--mining--p2pool]
+[o:dash:p:dash-docs:r:docs--user--mining--p2pool]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/mining/p2pool.po
 source_file = locale/pot/docs/user/mining/p2pool.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--mining--pools]
+[o:dash:p:dash-docs:r:docs--user--mining--pools]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/mining/pools.po
 source_file = locale/pot/docs/user/mining/pools.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--network--electrumx-server]
+[o:dash:p:dash-docs:r:docs--user--network--electrumx-server]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/network/electrumx-server.po
 source_file = locale/pot/docs/user/network/electrumx-server.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--hardware]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/hardware.po
-source_file = locale/pot/docs/user/wallets/hardware.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--index-hardware]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-hardware.po
-source_file = locale/pot/docs/user/wallets/index-hardware.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--index-paper]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-paper.po
-source_file = locale/pot/docs/user/wallets/index-paper.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--index-text]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-text.po
-source_file = locale/pot/docs/user/wallets/index-text.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--index-third-party]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-third-party.po
-source_file = locale/pot/docs/user/wallets/index-third-party.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--index-web]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-web.po
-source_file = locale/pot/docs/user/wallets/index-web.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index.po
-source_file = locale/pot/docs/user/wallets/index.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--paper]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/paper.po
-source_file = locale/pot/docs/user/wallets/paper.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--recovery]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/recovery.po
-source_file = locale/pot/docs/user/wallets/recovery.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--signing]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/signing.po
-source_file = locale/pot/docs/user/wallets/signing.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--text]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/text.po
-source_file = locale/pot/docs/user/wallets/text.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--third-party]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/third-party.po
-source_file = locale/pot/docs/user/wallets/third-party.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--web]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/web.po
-source_file = locale/pot/docs/user/wallets/web.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--android--advanced-functions]
+[o:dash:p:dash-docs:r:docs--user--wallets--android--advanced-functions]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/advanced-functions.po
 source_file = locale/pot/docs/user/wallets/android/advanced-functions.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--android--getting-started]
+[o:dash:p:dash-docs:r:docs--user--wallets--android--getting-started]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/getting-started.po
 source_file = locale/pot/docs/user/wallets/android/getting-started.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--android--index]
+[o:dash:p:dash-docs:r:docs--user--wallets--android--index]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/index.po
 source_file = locale/pot/docs/user/wallets/android/index.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--android--installation]
+[o:dash:p:dash-docs:r:docs--user--wallets--android--installation]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/installation.po
 source_file = locale/pot/docs/user/wallets/android/installation.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--dashcore--advanced]
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--advanced]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/advanced.po
 source_file = locale/pot/docs/user/wallets/dashcore/advanced.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--dashcore--backup]
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--backup]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/backup.po
 source_file = locale/pot/docs/user/wallets/dashcore/backup.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--dashcore--cmd-rpc]
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--cmd-rpc]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/cmd-rpc.po
 source_file = locale/pot/docs/user/wallets/dashcore/cmd-rpc.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--dashcore--coinjoin-instantsend]
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--coinjoin-instantsend]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/coinjoin-instantsend.po
 source_file = locale/pot/docs/user/wallets/dashcore/coinjoin-instantsend.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--dashcore--index]
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--index]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/index.po
 source_file = locale/pot/docs/user/wallets/dashcore/index.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--dashcore--installation-linux]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-linux.po
-source_file = locale/pot/docs/user/wallets/dashcore/installation-linux.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--dashcore--installation-macos]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-macos.po
-source_file = locale/pot/docs/user/wallets/dashcore/installation-macos.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--dashcore--installation-windows]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-windows.po
-source_file = locale/pot/docs/user/wallets/dashcore/installation-windows.pot
-source_lang = en
-type = PO
-
-[dash-docs.docs--user--wallets--dashcore--installation]
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation.po
 source_file = locale/pot/docs/user/wallets/dashcore/installation.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--dashcore--interface]
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation-linux]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-linux.po
+source_file = locale/pot/docs/user/wallets/dashcore/installation-linux.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation-macos]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-macos.po
+source_file = locale/pot/docs/user/wallets/dashcore/installation-macos.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation-windows]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-windows.po
+source_file = locale/pot/docs/user/wallets/dashcore/installation-windows.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--interface]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/interface.po
 source_file = locale/pot/docs/user/wallets/dashcore/interface.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--dashcore--send-receive]
+[o:dash:p:dash-docs:r:docs--user--wallets--dashcore--send-receive]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/send-receive.po
 source_file = locale/pot/docs/user/wallets/dashcore/send-receive.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--electrum--advanced]
+[o:dash:p:dash-docs:r:docs--user--wallets--electrum--advanced]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/advanced.po
 source_file = locale/pot/docs/user/wallets/electrum/advanced.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--electrum--faq]
+[o:dash:p:dash-docs:r:docs--user--wallets--electrum--faq]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/faq.po
 source_file = locale/pot/docs/user/wallets/electrum/faq.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--electrum--index]
+[o:dash:p:dash-docs:r:docs--user--wallets--electrum--index]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/index.po
 source_file = locale/pot/docs/user/wallets/electrum/index.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--electrum--installation]
+[o:dash:p:dash-docs:r:docs--user--wallets--electrum--installation]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/installation.po
 source_file = locale/pot/docs/user/wallets/electrum/installation.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--electrum--security]
+[o:dash:p:dash-docs:r:docs--user--wallets--electrum--security]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/security.po
 source_file = locale/pot/docs/user/wallets/electrum/security.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--electrum--send-receive]
+[o:dash:p:dash-docs:r:docs--user--wallets--electrum--send-receive]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/send-receive.po
 source_file = locale/pot/docs/user/wallets/electrum/send-receive.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--ios--advanced-functions]
+[o:dash:p:dash-docs:r:docs--user--wallets--hardware]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/hardware.po
+source_file = locale/pot/docs/user/wallets/hardware.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--index]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index.po
+source_file = locale/pot/docs/user/wallets/index.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--index-hardware]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-hardware.po
+source_file = locale/pot/docs/user/wallets/index-hardware.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--index-paper]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-paper.po
+source_file = locale/pot/docs/user/wallets/index-paper.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--index-text]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-text.po
+source_file = locale/pot/docs/user/wallets/index-text.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--index-third-party]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-third-party.po
+source_file = locale/pot/docs/user/wallets/index-third-party.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--index-web]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-web.po
+source_file = locale/pot/docs/user/wallets/index-web.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--ios--advanced-functions]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/advanced-functions.po
 source_file = locale/pot/docs/user/wallets/ios/advanced-functions.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--ios--getting-started]
+[o:dash:p:dash-docs:r:docs--user--wallets--ios--getting-started]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/getting-started.po
 source_file = locale/pot/docs/user/wallets/ios/getting-started.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--ios--index]
+[o:dash:p:dash-docs:r:docs--user--wallets--ios--index]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/index.po
 source_file = locale/pot/docs/user/wallets/ios/index.pot
 source_lang = en
-type = PO
+type        = PO
 
-[dash-docs.docs--user--wallets--ios--installation]
+[o:dash:p:dash-docs:r:docs--user--wallets--ios--installation]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/installation.po
 source_file = locale/pot/docs/user/wallets/ios/installation.pot
 source_lang = en
-type = PO
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--paper]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/paper.po
+source_file = locale/pot/docs/user/wallets/paper.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--recovery]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/recovery.po
+source_file = locale/pot/docs/user/wallets/recovery.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--signing]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/signing.po
+source_file = locale/pot/docs/user/wallets/signing.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--text]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/text.po
+source_file = locale/pot/docs/user/wallets/text.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--third-party]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/third-party.po
+source_file = locale/pot/docs/user/wallets/third-party.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:docs--user--wallets--web]
+file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/web.po
+source_file = locale/pot/docs/user/wallets/web.pot
+source_lang = en
+type        = PO
+
+[o:dash:p:dash-docs:r:index]
+file_filter = locale/<lang>/LC_MESSAGES/index.po
+source_file = locale/pot/index.pot
+source_lang = en
+type        = PO
 

--- a/.tx/config
+++ b/.tx/config
@@ -2,118 +2,155 @@
 host = https://www.transifex.com
 
 [o:dash:p:dash-docs:r:docs--user--developers--compiling]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/compiling.po
-source_file = locale/pot/docs/user/developers/compiling.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/developers/compiling.po
+source_file  = locale/pot/docs/user/developers/compiling.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--developers--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/index.po
-source_file = locale/pot/docs/user/developers/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/developers/index.po
+source_file  = locale/pot/docs/user/developers/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--developers--insight]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/insight.po
-source_file = locale/pot/docs/user/developers/insight.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/developers/insight.po
+source_file  = locale/pot/docs/user/developers/insight.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--developers--integration]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/integration.po
-source_file = locale/pot/docs/user/developers/integration.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/developers/integration.po
+source_file  = locale/pot/docs/user/developers/integration.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
+
+[o:dash:p:dash-docs:r:docs--user--developers--integration-apis]
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/developers/integration-apis.po
+source_file  = locale/pot/docs/user/developers/integration-apis.pot
+type         = PO
+minimum_perc = 0
+
+[o:dash:p:dash-docs:r:docs--user--developers--integration-sdks]
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/developers/integration-sdks.po
+source_file  = locale/pot/docs/user/developers/integration-sdks.pot
+type         = PO
+minimum_perc = 0
+
+[o:dash:p:dash-docs:r:docs--user--developers--sporks]
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/developers/sporks.po
+source_file  = locale/pot/docs/user/developers/sporks.pot
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--developers--testnet]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/testnet.po
-source_file = locale/pot/docs/user/developers/testnet.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/developers/testnet.po
+source_file  = locale/pot/docs/user/developers/testnet.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--developers--translating]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/developers/translating.po
-source_file = locale/pot/docs/user/developers/translating.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/developers/translating.po
+source_file  = locale/pot/docs/user/developers/translating.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--earning-spending]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/earning-spending.po
-source_file = locale/pot/docs/user/earning-spending.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/earning-spending.po
+source_file  = locale/pot/docs/user/earning-spending.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--governance--eight-steps]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/governance/eight-steps.po
-source_file = locale/pot/docs/user/governance/eight-steps.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/governance/eight-steps.po
+source_file  = locale/pot/docs/user/governance/eight-steps.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--governance--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/governance/index.po
-source_file = locale/pot/docs/user/governance/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/governance/index.po
+source_file  = locale/pot/docs/user/governance/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--governance--understanding]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/governance/understanding.po
-source_file = locale/pot/docs/user/governance/understanding.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/governance/understanding.po
+source_file  = locale/pot/docs/user/governance/understanding.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--governance--using]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/governance/using.po
-source_file = locale/pot/docs/user/governance/using.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/governance/using.po
+source_file  = locale/pot/docs/user/governance/using.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/index.po
-source_file = locale/pot/docs/user/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/index.po
+source_file  = locale/pot/docs/user/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--introduction--about]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/introduction/about.po
-source_file = locale/pot/docs/user/introduction/about.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/introduction/about.po
+source_file  = locale/pot/docs/user/introduction/about.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--introduction--features]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/introduction/features.po
-source_file = locale/pot/docs/user/introduction/features.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/introduction/features.po
+source_file  = locale/pot/docs/user/introduction/features.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--introduction--how-to-buy]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/introduction/how-to-buy.po
-source_file = locale/pot/docs/user/introduction/how-to-buy.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/introduction/how-to-buy.po
+source_file  = locale/pot/docs/user/introduction/how-to-buy.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--introduction--information]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/introduction/information.po
-source_file = locale/pot/docs/user/introduction/information.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/introduction/information.po
+source_file  = locale/pot/docs/user/introduction/information.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--introduction--safety]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/introduction/safety.po
-source_file = locale/pot/docs/user/introduction/safety.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/introduction/safety.po
+source_file  = locale/pot/docs/user/introduction/safety.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--legal]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/legal.po
-source_file = locale/pot/docs/user/legal.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/legal.po
+source_file  = locale/pot/docs/user/legal.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--marketing]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/marketing.po
-source_file = locale/pot/docs/user/marketing.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/marketing.po
+source_file  = locale/pot/docs/user/marketing.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--advanced]
 file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/advanced.po
@@ -122,296 +159,363 @@ source_lang = en
 type        = PO
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--hosting]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/hosting.po
-source_file = locale/pot/docs/user/masternodes/hosting.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/masternodes/hosting.po
+source_file  = locale/pot/docs/user/masternodes/hosting.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/index.po
-source_file = locale/pot/docs/user/masternodes/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/masternodes/index.po
+source_file  = locale/pot/docs/user/masternodes/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--maintenance]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/maintenance.po
-source_file = locale/pot/docs/user/masternodes/maintenance.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/masternodes/maintenance.po
+source_file  = locale/pot/docs/user/masternodes/maintenance.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
+
+[o:dash:p:dash-docs:r:docs--user--masternodes--server-config]
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/masternodes/server-config.po
+source_file  = locale/pot/docs/user/masternodes/server-config.pot
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--setup]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/setup.po
-source_file = locale/pot/docs/user/masternodes/setup.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/masternodes/setup.po
+source_file  = locale/pot/docs/user/masternodes/setup.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
+
+[o:dash:p:dash-docs:r:docs--user--masternodes--setup-hpmn]
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/masternodes/setup-hpmn.po
+source_file  = locale/pot/docs/user/masternodes/setup-hpmn.pot
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--setup-testnet]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/setup-testnet.po
-source_file = locale/pot/docs/user/masternodes/setup-testnet.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/masternodes/setup-testnet.po
+source_file  = locale/pot/docs/user/masternodes/setup-testnet.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--understanding]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/masternodes/understanding.po
-source_file = locale/pot/docs/user/masternodes/understanding.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/masternodes/understanding.po
+source_file  = locale/pot/docs/user/masternodes/understanding.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--mining--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/mining/index.po
-source_file = locale/pot/docs/user/mining/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/mining/index.po
+source_file  = locale/pot/docs/user/mining/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--mining--p2pool]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/mining/p2pool.po
-source_file = locale/pot/docs/user/mining/p2pool.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/mining/p2pool.po
+source_file  = locale/pot/docs/user/mining/p2pool.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--mining--pools]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/mining/pools.po
-source_file = locale/pot/docs/user/mining/pools.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/mining/pools.po
+source_file  = locale/pot/docs/user/mining/pools.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
+
+[o:dash:p:dash-docs:r:docs--user--network--dashmate--index]
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/network/dashmate/index.po
+source_file  = locale/pot/docs/user/network/dashmate/index.pot
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--network--electrumx-server]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/network/electrumx-server.po
-source_file = locale/pot/docs/user/network/electrumx-server.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/network/electrumx-server.po
+source_file  = locale/pot/docs/user/network/electrumx-server.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--android--advanced-functions]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/advanced-functions.po
-source_file = locale/pot/docs/user/wallets/android/advanced-functions.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/android/advanced-functions.po
+source_file  = locale/pot/docs/user/wallets/android/advanced-functions.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--android--getting-started]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/getting-started.po
-source_file = locale/pot/docs/user/wallets/android/getting-started.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/android/getting-started.po
+source_file  = locale/pot/docs/user/wallets/android/getting-started.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--android--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/index.po
-source_file = locale/pot/docs/user/wallets/android/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/index.po
+source_file  = locale/pot/docs/user/wallets/android/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--android--installation]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/installation.po
-source_file = locale/pot/docs/user/wallets/android/installation.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/installation.po
+source_file  = locale/pot/docs/user/wallets/android/installation.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--advanced]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/advanced.po
-source_file = locale/pot/docs/user/wallets/dashcore/advanced.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/advanced.po
+source_file  = locale/pot/docs/user/wallets/dashcore/advanced.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--backup]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/backup.po
-source_file = locale/pot/docs/user/wallets/dashcore/backup.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/backup.po
+source_file  = locale/pot/docs/user/wallets/dashcore/backup.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--cmd-rpc]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/cmd-rpc.po
-source_file = locale/pot/docs/user/wallets/dashcore/cmd-rpc.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/cmd-rpc.po
+source_file  = locale/pot/docs/user/wallets/dashcore/cmd-rpc.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--coinjoin-instantsend]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/coinjoin-instantsend.po
-source_file = locale/pot/docs/user/wallets/dashcore/coinjoin-instantsend.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/coinjoin-instantsend.po
+source_file  = locale/pot/docs/user/wallets/dashcore/coinjoin-instantsend.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/index.po
-source_file = locale/pot/docs/user/wallets/dashcore/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/index.po
+source_file  = locale/pot/docs/user/wallets/dashcore/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation.po
-source_file = locale/pot/docs/user/wallets/dashcore/installation.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation.po
+source_file  = locale/pot/docs/user/wallets/dashcore/installation.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation-linux]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-linux.po
-source_file = locale/pot/docs/user/wallets/dashcore/installation-linux.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-linux.po
+source_file  = locale/pot/docs/user/wallets/dashcore/installation-linux.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation-macos]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-macos.po
-source_file = locale/pot/docs/user/wallets/dashcore/installation-macos.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-macos.po
+source_file  = locale/pot/docs/user/wallets/dashcore/installation-macos.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation-windows]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-windows.po
-source_file = locale/pot/docs/user/wallets/dashcore/installation-windows.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-windows.po
+source_file  = locale/pot/docs/user/wallets/dashcore/installation-windows.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--interface]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/interface.po
-source_file = locale/pot/docs/user/wallets/dashcore/interface.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/interface.po
+source_file  = locale/pot/docs/user/wallets/dashcore/interface.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--send-receive]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/send-receive.po
-source_file = locale/pot/docs/user/wallets/dashcore/send-receive.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/send-receive.po
+source_file  = locale/pot/docs/user/wallets/dashcore/send-receive.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--advanced]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/advanced.po
-source_file = locale/pot/docs/user/wallets/electrum/advanced.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/advanced.po
+source_file  = locale/pot/docs/user/wallets/electrum/advanced.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--faq]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/faq.po
-source_file = locale/pot/docs/user/wallets/electrum/faq.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/faq.po
+source_file  = locale/pot/docs/user/wallets/electrum/faq.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/index.po
-source_file = locale/pot/docs/user/wallets/electrum/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/index.po
+source_file  = locale/pot/docs/user/wallets/electrum/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--installation]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/installation.po
-source_file = locale/pot/docs/user/wallets/electrum/installation.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/installation.po
+source_file  = locale/pot/docs/user/wallets/electrum/installation.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--security]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/security.po
-source_file = locale/pot/docs/user/wallets/electrum/security.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/security.po
+source_file  = locale/pot/docs/user/wallets/electrum/security.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--send-receive]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/send-receive.po
-source_file = locale/pot/docs/user/wallets/electrum/send-receive.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/send-receive.po
+source_file  = locale/pot/docs/user/wallets/electrum/send-receive.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--hardware]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/hardware.po
-source_file = locale/pot/docs/user/wallets/hardware.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/wallets/hardware.po
+source_file  = locale/pot/docs/user/wallets/hardware.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index.po
-source_file = locale/pot/docs/user/wallets/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/index.po
+source_file  = locale/pot/docs/user/wallets/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index-hardware]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-hardware.po
-source_file = locale/pot/docs/user/wallets/index-hardware.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/index-hardware.po
+source_file  = locale/pot/docs/user/wallets/index-hardware.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index-paper]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-paper.po
-source_file = locale/pot/docs/user/wallets/index-paper.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/index-paper.po
+source_file  = locale/pot/docs/user/wallets/index-paper.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index-text]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-text.po
-source_file = locale/pot/docs/user/wallets/index-text.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/index-text.po
+source_file  = locale/pot/docs/user/wallets/index-text.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index-third-party]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-third-party.po
-source_file = locale/pot/docs/user/wallets/index-third-party.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/index-third-party.po
+source_file  = locale/pot/docs/user/wallets/index-third-party.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index-web]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-web.po
-source_file = locale/pot/docs/user/wallets/index-web.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/index-web.po
+source_file  = locale/pot/docs/user/wallets/index-web.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--ios--advanced-functions]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/advanced-functions.po
-source_file = locale/pot/docs/user/wallets/ios/advanced-functions.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/ios/advanced-functions.po
+source_file  = locale/pot/docs/user/wallets/ios/advanced-functions.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--ios--getting-started]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/getting-started.po
-source_file = locale/pot/docs/user/wallets/ios/getting-started.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/ios/getting-started.po
+source_file  = locale/pot/docs/user/wallets/ios/getting-started.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--ios--index]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/index.po
-source_file = locale/pot/docs/user/wallets/ios/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/index.po
+source_file  = locale/pot/docs/user/wallets/ios/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--ios--installation]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/installation.po
-source_file = locale/pot/docs/user/wallets/ios/installation.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/ios/installation.po
+source_file  = locale/pot/docs/user/wallets/ios/installation.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--paper]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/paper.po
-source_file = locale/pot/docs/user/wallets/paper.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/paper.po
+source_file  = locale/pot/docs/user/wallets/paper.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--recovery]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/recovery.po
-source_file = locale/pot/docs/user/wallets/recovery.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/recovery.po
+source_file  = locale/pot/docs/user/wallets/recovery.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--signing]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/signing.po
-source_file = locale/pot/docs/user/wallets/signing.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/signing.po
+source_file  = locale/pot/docs/user/wallets/signing.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--text]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/text.po
-source_file = locale/pot/docs/user/wallets/text.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/text.po
+source_file  = locale/pot/docs/user/wallets/text.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--third-party]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/third-party.po
-source_file = locale/pot/docs/user/wallets/third-party.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/third-party.po
+source_file  = locale/pot/docs/user/wallets/third-party.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:docs--user--wallets--web]
-file_filter = locale/<lang>/LC_MESSAGES/docs/user/wallets/web.po
-source_file = locale/pot/docs/user/wallets/web.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/docs/user/wallets/web.po
+source_file  = locale/pot/docs/user/wallets/web.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 
 [o:dash:p:dash-docs:r:index]
-file_filter = locale/<lang>/LC_MESSAGES/index.po
-source_file = locale/pot/index.pot
-source_lang = en
-type        = PO
+file_filter  = locale//<lang>/LC_MESSAGES/index.po
+source_file  = locale/pot/index.pot
+source_lang  = en
+type         = PO
+minimum_perc = 0
 

--- a/transifex/README.md
+++ b/transifex/README.md
@@ -6,9 +6,17 @@ information.
 
 ## Install required packages
 
+Install the [sphinx-intl](https://pypi.org/project/sphinx-intl/) utility.
+
+```shell
+pip install sphinx-intl==2.1.0
+```
+
+Also install the Transifex CLI client as described in the [repository's
+README](https://github.com/transifex/cli/tree/devel#transifex-client).
+
 ``` shell
-pip install sphinx-intl
-pip install transifex-client==0.13.12
+curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
 ```
 
 ## Set webhook variables

--- a/transifex/pulltx.sh
+++ b/transifex/pulltx.sh
@@ -22,6 +22,6 @@ while sleep 1;do procs=$(ps aux);echo "$procs"|grep -q "tx pull -f -l"||break;do
 echo "tx pulls are all done now."
 
 # Add changes to repo and push to upstream so a pull request can be opened
-git add locale/*
-git commit -m "Refresh translations from Transifex"
-git push --set-upstream origin $BRANCH_NAME
+# git add locale/*
+# git commit -m "Refresh translations from Transifex"
+# git push --set-upstream origin $BRANCH_NAME

--- a/transifex/pulltx.sh
+++ b/transifex/pulltx.sh
@@ -1,5 +1,5 @@
 # Set to the dashpay/docs branch containing the version to update
-DOC_VERSION=18.0.0
+DOC_VERSION=master
 
 DAY=$(date +%d)
 MONTH=$(date +%m)

--- a/transifex/pulltx.sh
+++ b/transifex/pulltx.sh
@@ -22,6 +22,6 @@ while sleep 1;do procs=$(ps aux);echo "$procs"|grep -q "tx pull -f -l"||break;do
 echo "tx pulls are all done now."
 
 # Add changes to repo and push to upstream so a pull request can be opened
-# git add locale/*
-# git commit -m "Refresh translations from Transifex"
-# git push --set-upstream origin $BRANCH_NAME
+git add locale/*
+git commit -m "Refresh translations from Transifex"
+git push --set-upstream origin $BRANCH_NAME

--- a/transifex/pushtx.sh
+++ b/transifex/pushtx.sh
@@ -19,4 +19,4 @@ sphinx-intl update -l en
 sphinx-intl update-txconfig-resources --pot-dir locale/pot  --transifex-organization-name dash --transifex-project-name dash-docs
 
 # Push to Transifex
-# tx push --source --force --no-interactive
+tx push --source --force

--- a/transifex/pushtx.sh
+++ b/transifex/pushtx.sh
@@ -1,5 +1,5 @@
 # Set to the dashpay/docs branch containing the version to update
-DOC_VERSION=18.0.0
+DOC_VERSION=master
 
 # Checkout correct branch and pull changes
 git fetch

--- a/transifex/pushtx.sh
+++ b/transifex/pushtx.sh
@@ -19,4 +19,4 @@ sphinx-intl update -l en
 sphinx-intl update-txconfig-resources --pot-dir locale/pot --transifex-project-name dash-docs
 
 # Push to Transifex
-tx push --source --force --no-interactive
+# tx push --source --force --no-interactive

--- a/transifex/pushtx.sh
+++ b/transifex/pushtx.sh
@@ -16,7 +16,7 @@ if [ $? -eq 0 ]; then echo "make issued a WARNING, bailing out...";exit 2;fi
 # Update files for all languages
 sphinx-intl update -p _build/gettext -l de -l pt -l ko -l el -l ar -l ru -l zh_CN -l fr -l es -l ja -l vi -l zh_TW -l it -l tl
 sphinx-intl update -l en
-sphinx-intl update-txconfig-resources --pot-dir locale/pot --transifex-project-name dash-docs
+sphinx-intl update-txconfig-resources --pot-dir locale/pot  --transifex-organization-name dash --transifex-project-name dash-docs
 
 # Push to Transifex
 # tx push --source --force --no-interactive


### PR DESCRIPTION
Transifex has migrated to V3 of their API and no longer support V2. The existing tool we were using ([transifex-client](https://github.com/transifex/transifex-client)) has been deprecated in favor of a [new CLI client](https://github.com/transifex/cli). This PR updates our scripts, config, and Readme to use that new client (which is still called `tx` - thus the lack of many changes.

I tested this and it seems to all work. I successfully pushed and see the updated files on the Transifex site. I also did a successful pull back out of Transifex. Results of the push can be seen here: https://github.com/thephez/dash-user-docs/pull/29. I think those changes are mainly due to this being the first push in a while and some new pages were added.

Since we keep `master` in sync with the latest version typically, I switched the target branch to that so we don't have to remember to update the scripts each time we release.

<!-- Replace -->
Preview build: https://dash-docs--256.org.readthedocs.build/en/256/
<!-- Replace -->
