### PR TITLE
chore: add mo files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _build
 **/.DS_Store
 .vscode
 transifex/.env
+*.mo


### PR DESCRIPTION
And when I say "mo" files, I mean ".mo" files, not mo' files. :smile: 
Sphinx will generate them from .po files so they shouldn't be included in the repo