### PR TITLE
chore: update sphinx to 6.2

### DIFF
--- a/_static/css/footer.css
+++ b/_static/css/footer.css
@@ -1,11 +1,7 @@
 /* Make each footer item in-line so they stack horizontally instead of vertically */
-.footer-item {
-  display: inline-block;
-}
-
-/* Add a separating border line for all but the last item */
-.footer-item:not(:last-child) {
-  border-right: 1px solid var(--pst-color-text-base);
-  margin-right: .5em;
-  padding-right: .5em;
+.bd-footer .footer-items__start {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  justify-content: space-between;
 }

--- a/_static/js/temp-header-fix.js
+++ b/_static/js/temp-header-fix.js
@@ -1,0 +1,6 @@
+// Will not be necessary after https://github.com/pydata/pydata-sphinx-theme/pull/1331 is released
+// Found in https://github.com/pydata/pydata-sphinx-theme/issues/1235#issuecomment-1463932759
+$(document).ready(function () {
+  var fixalign = document.getElementsByClassName("navbar-header-items__start")
+  fixalign[0].classList.add("col-lg-3");
+});

--- a/conf.py
+++ b/conf.py
@@ -270,3 +270,4 @@ texinfo_documents = [
 
 def setup(app):
     app.add_js_file('js/lang.js')
+    app.add_js_file('js/temp-header-fix.js')

--- a/conf.py
+++ b/conf.py
@@ -97,6 +97,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx_copybutton',
     'sphinx_design',
+    'sphinx_favicon',
     'sphinx.ext.intersphinx',
 ]
 
@@ -145,28 +146,6 @@ html_theme_options = {
     "github_url": "https://github.com/dashpay/docs",
     "show_toc_level": 2,
     "show_nav_level": 1,
-    "favicons": [
-      {
-         "rel": "icon",
-         "sizes": "16x16",
-         "href": "img/favicon-16x16.png",
-      },
-      {
-         "rel": "icon",
-         "sizes": "32x32",
-         "href": "img/favicon-32x32.png",
-      },
-      {
-         "rel": "icon",
-         "sizes": "96x96",
-         "href": "img/favicon-96x96.png",
-      },
-      {
-         "rel": "icon",
-         "sizes": "144x144",
-         "href": "img/favicon-144x144.png",
-      },
-   ],
 #    "navbar_start": ["navbar-logo", "languages"],
 #    "navbar_center": ["languages", "navbar-nav", "languages"],
 #    "navbar_end": ["navbar-icon-links", "version"],
@@ -193,6 +172,14 @@ html_static_path = ['_static']
 html_css_files = [
     'css/footer.css',
     'css/pydata-overrides.css',
+]
+
+# -- Options for sphinx-favicon -------------------------------------------
+favicons = [
+    "img/favicon-16x16.png",
+    "img/favicon-32x32.png",
+    "img/favicon-96x96.png",
+    "img/favicon-144x144.png",
 ]
 
 # Override to allow text wrap in tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Babel==2.12.1
 myst-parser==1.0.0
 pydata-sphinx-theme==0.12.0
-sphinx==5.3.0
+sphinx==6.2.1
 sphinx-copybutton==0.5.2
 sphinx-hoverxref==1.3.0
 sphinx_design==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ myst-parser==1.0.0
 pydata-sphinx-theme==0.13.3
 sphinx==6.2.1
 sphinx-copybutton==0.5.2
+sphinx-favicon==1.0.1
 sphinx-hoverxref==1.3.0
 sphinx_design==0.4.1
 jinja2==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Babel==2.12.1
 myst-parser==1.0.0
-pydata-sphinx-theme==0.12.0
+pydata-sphinx-theme==0.13.3
 sphinx==6.2.1
 sphinx-copybutton==0.5.2
 sphinx-hoverxref==1.3.0


### PR DESCRIPTION
Moves to almost the newest version of sphinx so we shouldn't have to change this again anytime soon. It also requires bumping the theme to a newer version and adding the favicon extension. Some CSS/JS updates also required to make the footer stay similar to how it was.

The updated theme uses a larger font, adds navigation breadcrumbs, and tweaks some other things. It still doesn't have improved search support yet unfortunately. 

Please click through a few pages and see if you notice any issues: https://dash-docs--278.org.readthedocs.build/en/278/index.html

![image](https://github.com/dashpay/docs/assets/8145677/2ba804f8-a623-4062-998d-6ab6710f0333)
