### PR TITLE
docs(integration): add chainlocks section info

### DIFF
--- a/docs/user/developers/integration.rst
+++ b/docs/user/developers/integration.rst
@@ -190,14 +190,14 @@ daemon using JSON-RPC protocol. The ``instantlock`` attribute of the JSON
 response reflects the status of the transaction and is included in the following
 commands:
 
-   - :ref:`getrawmempool <core:api-rpc-blockchain-getrawmempool>`
-   - :ref:`getmempoolancestors <core:api-rpc-blockchain-getmempoolancestors>`
-   - :ref:`getmempooldescendants <core:api-rpc-blockchain-getmempooldescendants>`
-   - :ref:`getmempoolentry <core:api-rpc-blockchain-getmempoolentry>`
-   - :ref:`getrawtransaction <core:api-rpc-raw-transactions-getrawtransaction>`
-   - :ref:`gettransaction <core:api-rpc-wallet-gettransaction>`
-   - :ref:`listtransactions <core:api-rpc-wallet-listtransactions>`
-   - :ref:`listsinceblock <core:api-rpc-wallet-listsinceblock>`
+- :ref:`getrawmempool <core:api-rpc-blockchain-getrawmempool>`
+- :ref:`getmempoolancestors <core:api-rpc-blockchain-getmempoolancestors>`
+- :ref:`getmempooldescendants <core:api-rpc-blockchain-getmempooldescendants>`
+- :ref:`getmempoolentry <core:api-rpc-blockchain-getmempoolentry>`
+- :ref:`getrawtransaction <core:api-rpc-raw-transactions-getrawtransaction>`
+- :ref:`gettransaction <core:api-rpc-wallet-gettransaction>`
+- :ref:`listtransactions <core:api-rpc-wallet-listtransactions>`
+- :ref:`listsinceblock <core:api-rpc-wallet-listsinceblock>`
 
 ZMQ Notification
 ^^^^^^^^^^^^^^^^
@@ -312,13 +312,13 @@ daemon using JSON-RPC protocol. The boolean ``chainlock`` attribute of the JSON
 response reflects the ChainLock status of the block or transaction and is
 included in the following commands:
 
-   - :ref:`getblock <core:api-rpc-blockchain-getblock>`
-   - :ref:`getblockheaders <core:api-rpc-blockchain-getblockheader>`
-   - :ref:`getblockheaders <core:api-rpc-blockchain-getblockheaders>`
-   - :ref:`getrawtransaction <core:api-rpc-raw-transactions-getrawtransaction>`
-   - :ref:`gettransaction <core:api-rpc-wallet-gettransaction>`
-   - :ref:`listtransactions <core:api-rpc-wallet-listtransactions>`
-   - :ref:`listsinceblock <core:api-rpc-wallet-listsinceblock>`
+- :ref:`getblock <core:api-rpc-blockchain-getblock>`
+- :ref:`getblockheader <core:api-rpc-blockchain-getblockheader>`
+- :ref:`getblockheaders <core:api-rpc-blockchain-getblockheaders>`
+- :ref:`getrawtransaction <core:api-rpc-raw-transactions-getrawtransaction>`
+- :ref:`gettransaction <core:api-rpc-wallet-gettransaction>`
+- :ref:`listtransactions <core:api-rpc-wallet-listtransactions>`
+- :ref:`listsinceblock <core:api-rpc-wallet-listsinceblock>`
 
 ZMQ Notification
 ^^^^^^^^^^^^^^^^

--- a/docs/user/developers/integration.rst
+++ b/docs/user/developers/integration.rst
@@ -203,9 +203,10 @@ ZMQ Notification
 ^^^^^^^^^^^^^^^^
 
 Whenever a transaction enters the mempool and whenever a transaction is locked
-in the mempool, ZMQ notifications can be broadcast by the node. A list of
-possible ZMQ notifications can be found `here
-<https://github.com/dashpay/dash/blob/master/doc/zmq.md#usage>`__. 
+in the mempool, ZMQ notifications can be broadcast by the node. Refer to `the
+list of possible ZMQ notifications
+<https://github.com/dashpay/dash/blob/master/doc/zmq.md#usage>`__ for more
+details.
 
 The following notifications are relevant for recognizing transactions
 and their corresponding instantlocks:
@@ -326,9 +327,10 @@ ZMQ Notification
 ChainLock signatures are created shortly after the related block has been mined.
 As a result it is recommended that integrated clients use :ref:`ZMQ (ZeroMQ)
 notifications <core:examples-receiving-zmq-notifications>` in order to ensure
-that this information is received as promptly as possible. A list of possible
-ZMQ notifications can be found `here
-<https://github.com/dashpay/dash/blob/master/doc/zmq.md#usage>`__. 
+that this information is received as promptly as possible. Refer to `the
+list of possible ZMQ notifications
+<https://github.com/dashpay/dash/blob/master/doc/zmq.md#usage>`__ for more
+details.
 
 The following notifications are relevant for recognizing blocks and their
 corresponding ChainLocks:

--- a/docs/user/developers/integration.rst
+++ b/docs/user/developers/integration.rst
@@ -311,3 +311,27 @@ As a result it is recommended that integrated clients use ZMQ (ZeroMQ)
 notifications in order to ensure that this information is received as promptly
 as possible. 
 
+This sample code uses the `js-dashd-zmq library
+<https://github.com/dashpay/js-dashd-zmq>`__ to listen for ChainLock ZMQ
+notifications and return the hash of blocks that receive a ChainLock. 
+
+.. code-block:: javascript
+   :caption: chainlock-zmq.js
+
+   const { ChainLock } = require('@dashevo/dashcore-lib');
+   const ZMQClient = require('@dashevo/dashd-zmq');
+   const client = new ZMQClient({
+   protocol: 'tcp',
+   host: '0.0.0.0',
+   port: '20009',
+   });
+
+   (async () => {
+      await client.connect();
+      client.subscribe(ZMQClient.TOPICS.rawchainlock);
+      client.subscribe(ZMQClient.TOPICS.hashchainlock);
+      client.on(ZMQClient.TOPICS.hashchainlock, async (hashChainLockMessage) => {
+         console.log(`ChainLock received for block ${hashChainLockMessage}`)
+         });    
+   })();
+

--- a/docs/user/developers/integration.rst
+++ b/docs/user/developers/integration.rst
@@ -308,9 +308,9 @@ Direct Connection
 ^^^^^^^^^^^^^^^^^
 
 ChainLock status can be identified through direct connection with the Dash
-daemon using JSON-RPC protocol. The ``chainlock`` attribute of the JSON response
-reflects the status of the block or transaction and is included in the following
-commands:
+daemon using JSON-RPC protocol. The boolean ``chainlock`` attribute of the JSON
+response reflects the ChainLock status of the block or transaction and is
+included in the following commands:
 
    - :ref:`getblock <core:api-rpc-blockchain-getblock>`
    - :ref:`getblockheaders <core:api-rpc-blockchain-getblockheader>`

--- a/docs/user/developers/integration.rst
+++ b/docs/user/developers/integration.rst
@@ -287,6 +287,19 @@ user experience. ChainLocks are a solution for this problem.
 Receiving ChainLocks
 --------------------
 
+.. note::
+
+   Once a ChainLock is observed for a block, each transaction in that block and
+   all previous blocks can be considered irreversibly and fully confirmed.
+
+Receiving a ChainLock introduces two requirements:
+
+1. The ability to determine the “ChainLock Status” of a given block or
+   transaction.
+
+2. The ability to adjust “Confirmation Status” independently of block
+   confirmation.
+
 ChainLock status is typically determined through direct connection with the Dash
 daemon or by a `ZMQ notification
 <https://github.com/dashpay/dash/blob/master/doc/zmq.md#usage>`__.
@@ -313,14 +326,25 @@ ZMQ Notification
 ChainLock signatures are created shortly after the related block has been mined.
 As a result it is recommended that integrated clients use :ref:`ZMQ (ZeroMQ)
 notifications <core:examples-receiving-zmq-notifications>` in order to ensure
-that this information is received as promptly as possible. 
+that this information is received as promptly as possible. A list of possible
+ZMQ notifications can be found `here
+<https://github.com/dashpay/dash/blob/master/doc/zmq.md#usage>`__. 
+
+The following notifications are relevant for recognizing blocks and their
+corresponding ChainLocks:
+
+- zmqpubhashblock
+- zmqpubhashchainlock
+- zmqpubrawblock
+- zmqpubrawchainlock
+- zmqpubrawchainlocksig
 
 This sample code uses the `js-dashd-zmq library
 <https://github.com/dashpay/js-dashd-zmq>`__ to listen for ChainLock ZMQ
 notifications and return the hash of blocks that receive a ChainLock. 
 
 .. code-block:: javascript
-   :caption: chainlock-zmq.js
+   :caption: Subscribe to ChainLock hash ZMQ notifications
 
    const { ChainLock } = require('@dashevo/dashcore-lib');
    const ZMQClient = require('@dashevo/dashd-zmq');
@@ -332,7 +356,6 @@ notifications and return the hash of blocks that receive a ChainLock.
 
    (async () => {
       await client.connect();
-      client.subscribe(ZMQClient.TOPICS.rawchainlock);
       client.subscribe(ZMQClient.TOPICS.hashchainlock);
       client.on(ZMQClient.TOPICS.hashchainlock, async (hashChainLockMessage) => {
          console.log(`ChainLock received for block ${hashChainLockMessage}`)
@@ -350,4 +373,3 @@ technologies.
 - :ref:`Receiving ZMQ notifications <core:examples-receiving-zmq-notifications>`
 - `DIP0008: ChainLocks <https://github.com/dashpay/dips/blob/master/dip-0008.md>`__
 - `Product Brief: Dash Core v0.14 Release <https://blog.dash.org/product-brief-dash-core-release-v0-14-0-now-on-testnet-8f5f4ad45c96>`__
-

--- a/docs/user/developers/integration.rst
+++ b/docs/user/developers/integration.rst
@@ -264,6 +264,7 @@ underlying technologies.
 
 - `InstantSend Technical Information <https://github.com/dashpay/dash/blob/master/doc/instantsend.md#zmq>`__
 - :ref:`InstantSend Developer Documentation <core:guide-features-instantsend>`
+- :ref:`Receiving ZMQ notifications <core:examples-receiving-zmq-notifications>`
 - `DIP0010: LLMQ InstantSend <https://github.com/dashpay/dips/blob/master/dip-0010.md>`__
 - `Product Brief: Dash Core v0.14 Release <https://blog.dash.org/product-brief-dash-core-release-v0-14-0-now-on-testnet-8f5f4ad45c96>`__
 
@@ -310,9 +311,9 @@ ZMQ Notification
 ^^^^^^^^^^^^^^^^
 
 ChainLock signatures are created shortly after the related block has been mined.
-As a result it is recommended that integrated clients use ZMQ (ZeroMQ)
-notifications in order to ensure that this information is received as promptly
-as possible. 
+As a result it is recommended that integrated clients use :ref:`ZMQ (ZeroMQ)
+notifications <core:examples-receiving-zmq-notifications>` in order to ensure
+that this information is received as promptly as possible. 
 
 This sample code uses the `js-dashd-zmq library
 <https://github.com/dashpay/js-dashd-zmq>`__ to listen for ChainLock ZMQ
@@ -324,9 +325,9 @@ notifications and return the hash of blocks that receive a ChainLock.
    const { ChainLock } = require('@dashevo/dashcore-lib');
    const ZMQClient = require('@dashevo/dashd-zmq');
    const client = new ZMQClient({
-   protocol: 'tcp',
-   host: '0.0.0.0',
-   port: '20009',
+      protocol: 'tcp',
+      host: '0.0.0.0',
+      port: '20009',
    });
 
    (async () => {
@@ -335,7 +336,7 @@ notifications and return the hash of blocks that receive a ChainLock.
       client.subscribe(ZMQClient.TOPICS.hashchainlock);
       client.on(ZMQClient.TOPICS.hashchainlock, async (hashChainLockMessage) => {
          console.log(`ChainLock received for block ${hashChainLockMessage}`)
-         });    
+      });
    })();
 
 Additional Resources
@@ -346,6 +347,7 @@ intended to help provide a more complete understanding of the underlying
 technologies.
 
 - :ref:`ChainLock Developer Documentation <core:guide-features-chainlocks>`
+- :ref:`Receiving ZMQ notifications <core:examples-receiving-zmq-notifications>`
 - `DIP0008: ChainLocks <https://github.com/dashpay/dips/blob/master/dip-0008.md>`__
 - `Product Brief: Dash Core v0.14 Release <https://blog.dash.org/product-brief-dash-core-release-v0-14-0-now-on-testnet-8f5f4ad45c96>`__
 

--- a/docs/user/developers/integration.rst
+++ b/docs/user/developers/integration.rst
@@ -338,3 +338,14 @@ notifications and return the hash of blocks that receive a ChainLock.
          });    
    })();
 
+Additional Resources
+--------------------
+
+The following resources provide additional information about InstantSend and are
+intended to help provide a more complete understanding of the underlying
+technologies.
+
+- :ref:`ChainLock Developer Documentation <core:guide-features-chainlocks>`
+- `DIP0008: ChainLocks <https://github.com/dashpay/dips/blob/master/dip-0008.md>`__
+- `Product Brief: Dash Core v0.14 Release <https://blog.dash.org/product-brief-dash-core-release-v0-14-0-now-on-testnet-8f5f4ad45c96>`__
+

--- a/docs/user/developers/integration.rst
+++ b/docs/user/developers/integration.rst
@@ -266,3 +266,48 @@ underlying technologies.
 - :ref:`InstantSend Developer Documentation <core:guide-features-instantsend>`
 - `DIP0010: LLMQ InstantSend <https://github.com/dashpay/dips/blob/master/dip-0010.md>`__
 - `Product Brief: Dash Core v0.14 Release <https://blog.dash.org/product-brief-dash-core-release-v0-14-0-now-on-testnet-8f5f4ad45c96>`__
+
+.. _integration-chainlocks:
+
+ChainLocks
+==========
+
+ChainLocks are a feature provided by the Dash Network which provides certainty
+when accepting payments. This technology, particularly when used in parallel
+with :ref:`InstantSend <instantsend>`, creates an environment in which payments
+can be accepted immediately and without the risk of “Blockchain Reorganization
+Events”.
+
+The risk of blockchain reorganization is typically addressed by requiring
+multiple :term:`confirmations` before a transaction can be safely accepted as
+payment. This type of indirect security is effective, but at a cost of time and
+user experience. ChainLocks are a solution for this problem.
+
+Receiving ChainLocks
+--------------------
+
+ChainLock status is typically determined through direct connection with the Dash
+daemon or by a `ZMQ notification
+<https://github.com/dashpay/dash/blob/master/doc/zmq.md#usage>`__.
+
+Direct Connection
+^^^^^^^^^^^^^^^^^
+
+ChainLock status can be identified through direct connection with the Dash
+daemon using JSON-RPC protocol. The ``chainlock`` attribute of the JSON response
+reflects the status of the block or transaction and is included in the following
+commands:
+
+   - :ref:`getrawtransaction <core:api-rpc-raw-transactions-getrawtransaction>`
+   - :ref:`gettransaction <core:api-rpc-wallet-gettransaction>`
+   - :ref:`listtransactions <core:api-rpc-wallet-listtransactions>`
+   - :ref:`listsinceblock <core:api-rpc-wallet-listsinceblock>`
+
+ZMQ Notification
+^^^^^^^^^^^^^^^^
+
+ChainLock signatures are created shortly after the related block has been mined.
+As a result it is recommended that integrated clients use ZMQ (ZeroMQ)
+notifications in order to ensure that this information is received as promptly
+as possible. 
+

--- a/docs/user/developers/integration.rst
+++ b/docs/user/developers/integration.rst
@@ -298,6 +298,9 @@ daemon using JSON-RPC protocol. The ``chainlock`` attribute of the JSON response
 reflects the status of the block or transaction and is included in the following
 commands:
 
+   - :ref:`getblock <core:api-rpc-blockchain-getblock>`
+   - :ref:`getblockheaders <core:api-rpc-blockchain-getblockheader>`
+   - :ref:`getblockheaders <core:api-rpc-blockchain-getblockheaders>`
    - :ref:`getrawtransaction <core:api-rpc-raw-transactions-getrawtransaction>`
    - :ref:`gettransaction <core:api-rpc-wallet-gettransaction>`
    - :ref:`listtransactions <core:api-rpc-wallet-listtransactions>`

--- a/docs/user/introduction/information.rst
+++ b/docs/user/introduction/information.rst
@@ -375,6 +375,8 @@ Glossary
     number increases as more blocks are added to the blockchain.
 
   Confirmation Number
+  confirmations
+
     The number of confirmations for a specific Dash transaction. Zero
     confirmations means that the **transaction is unconfirmed**. One
     confirmation means that the transaction is included in the latest


### PR DESCRIPTION
The integration page has had info about InstantSend for quite a while, but nothing about ChainLocks. This PR adds a ChainLocks section with basic info.

Builds on work started in #215 

<!-- Replace -->
Preview build: https://dash-docs--290.org.readthedocs.build/en/290/docs/user/developers/integration.html#chainlocks
<!-- Replace -->
