### PR TITLE
docs: add tokenview explorer

### DIFF
--- a/docs/user/introduction/information.rst
+++ b/docs/user/introduction/information.rst
@@ -152,11 +152,11 @@ Block explorers, statistics and visualizations
 - https://insight.dash.org/insight/
 - https://blockchair.com/dash
 - https://chainz.cryptoid.info/dash/
-- https://www.coinexplorer.net/dash
 - https://www.oklink.com/dash
 - https://bitinfocharts.com/dash/explorer/
 - https://dashblockexplorer.com
 - https://live.blockcypher.com/dash/
+- https://dash.tokenview.io
 - https://udjinm6.github.io/bitlisten/
 
 


### PR DESCRIPTION
Adds explorer proposed on dashpay/docs-core#58
Also removes an explorer that stopped updating blocks 6 yrs ago

<!-- Replace -->
Preview build: https://dash-docs--291.org.readthedocs.build/en/291/
<!-- Replace -->
