### PR TITLE
docs: v20 sentinel deprecation

### DIFF
--- a/docs/user/developers/testnet.rst
+++ b/docs/user/developers/testnet.rst
@@ -98,12 +98,6 @@ but with a few key differences:
   ``testnet = 1``
 - As for mainnet masternodes, the RPC username and password must contain
   alphanumeric characters only
-- When cloning sentinel, you may need to clone the development branch
-  using the ``-b`` option, for example: ``git clone -b develop
-  https://github.com/dashpay/sentinel.git``
-- Once sentinel is installed, modify
-  ``~/.dashcore/sentinel/sentinel.conf``, comment the mainnet line and
-  uncomment: ``network=testnet``
 - The wallet holding the masternode collateral will expect to find the
   ``masternode.conf`` file in ``~/.dashcore/testnet3/masternode.conf``
   instead of ``~/.dashcore/masternode.conf``.
@@ -270,4 +264,3 @@ Discussion:
 Latest successfully built develop branch binaries:
 
 - Dash Core: https://gitlab.com/dashpay/dash/pipelines
-- Sentinel: https://github.com/dashpay/sentinel/tree/develop

--- a/docs/user/introduction/features.rst
+++ b/docs/user/introduction/features.rst
@@ -558,6 +558,11 @@ of this documentation.
 Sentinel
 =========
 
+.. attention::
+
+   Sentinel was deprecated in Dash Core v20.0 when its functionality was
+   integrated into Dash Core.
+
 Introduced in Dash 0.12.1, Sentinel is an autonomous agent for
 persisting, processing and automating Dash governance objects and tasks.
 Sentinel is implemented as a Python application that binds to a local

--- a/docs/user/masternodes/maintenance.rst
+++ b/docs/user/masternodes/maintenance.rst
@@ -76,18 +76,7 @@ Restart Dash::
 
   ~/.dashcore/dashd
 
-You will see a message reading "Dash Core server starting". We will now
-update Sentinel::
-
-  cd ~/.dashcore/sentinel/
-  git checkout master
-  git pull
-  venv/bin/pip install -r requirements.txt
-
-Finally, uncomment the line to automatically restart Dash in your
-crontab by invoking ``crontab -e`` again and deleting the ``#``
-character.
-
+You will see a message reading "Dash Core server starting".
 The Dash software on the masternode is now updated.
 
 
@@ -237,8 +226,6 @@ the following settings are configured correctly:
 - Ensure that the ``externalip`` (and ``port`` if using testnet) are 
   specified correctly and not blocked by a firewall or port forwarding 
   service
-- Ensure that Sentinel is installed, updated, not exiting with an error 
-  and is entered in your crontab to run every 1-2 minutes
 
 Once you are certain these settings are correct, you can update your
 service status on the network and return to the valid set of masternodes
@@ -430,8 +417,8 @@ payment queue. Type the following command::
 
   crontab -e
 
-Select an editor if necessary and add the following line to your crontab
-after the line for sentinel, replacing lwhite with your username on your
+Select an editor if necessary and add the following line at the end of
+your crontab, replacing lwhite with your username on your
 system::
 
   */2 * * * * /home/lwhite/dashcentral-updater/dcupdater

--- a/docs/user/masternodes/setup-evonode.rst
+++ b/docs/user/masternodes/setup-evonode.rst
@@ -344,30 +344,14 @@ synchronization with the blockchain::
 
 You will see a message reading **Dash Core server starting**. 
 
-
-Sentinel
-^^^^^^^^
-
-We will now install Sentinel, a piece of software which operates as a watchdog
-to communicate to the network that your node is working properly::
-
-  cd ~/.dashcore
-  git clone https://github.com/dashpay/sentinel.git
-  cd sentinel
-  virtualenv venv
-  venv/bin/pip install -r requirements.txt
-  venv/bin/python bin/sentinel.py
-
-You will see a message reading **dashd not synced with network! Awaiting
-full sync before running Sentinel.** Add dashd and sentinel to crontab
-to make sure it runs every minute to check on your masternode::
+Add dashd to crontab to make sure it runs every minute to check on your
+masternode::
 
   crontab -e
 
 Choose nano as your editor and enter the following lines at the end of
 the file::
 
-  * * * * * cd ~/.dashcore/sentinel && ./venv/bin/python bin/sentinel.py 2>&1 >> sentinel-cron.log
   * * * * * pidof dashd || ~/.dashcore/dashd
 
 Press enter to make sure there is a blank line at the end of the file,

--- a/docs/user/masternodes/setup-testnet.rst
+++ b/docs/user/masternodes/setup-testnet.rst
@@ -751,28 +751,6 @@ Verify Dash Core is running::
 
   sudo systemctl status dashd
 
-Sentinel
-^^^^^^^^
-
-Sentinel is a watchdog and works to communicate to the network that your
-node is working properly. Install Sentinel as follows::
-
-  cd
-  sudo apt install -y software-properties-common python3-venv
-  git clone --depth 1 --branch master https://github.com/dashpay/sentinel.git
-  cd sentinel
-  python3 -m venv . sentinel
-  bin/pip install -r requirements.txt
-  bin/python bin/sentinel.py
-
-You will see a message reading **dashd not synced with network! Awaiting
-full sync before running Sentinel.** Run the following to ensure
-Sentinel runs every 10 minutes::
-
-  cat << EOF | crontab
-  */10 * * * * { test -f ~/.dashcore/testnet3/dashd.pid && cd ~/sentinel && bin/python bin/sentinel.py; } >> ~/sentinel/sentinel-cron.log 2>&1
-  EOF
-
 Use the following command to monitor sync status::
 
   dash-cli mnsync status

--- a/docs/user/masternodes/setup.rst
+++ b/docs/user/masternodes/setup.rst
@@ -304,27 +304,16 @@ synchronization with the blockchain::
 
   ~/.dashcore/dashd
 
-You will see a message reading **Dash Core server starting**. We will
-now install Sentinel, a piece of software which operates as a watchdog
-to communicate to the network that your node is working properly::
+You will see a message reading **Dash Core server starting**. 
 
-  cd ~/.dashcore
-  git clone https://github.com/dashpay/sentinel.git
-  cd sentinel
-  virtualenv venv
-  venv/bin/pip install -r requirements.txt
-  venv/bin/python bin/sentinel.py
-
-You will see a message reading **dashd not synced with network! Awaiting
-full sync before running Sentinel.** Add dashd and sentinel to crontab
-to make sure it runs every minute to check on your masternode::
+Add dashd to crontab to make sure it runs every minute to check on your
+masternode::
 
   crontab -e
 
-Choose nano as your editor and enter the following lines at the end of
+Choose nano as your editor and enter the following line at the end of
 the file::
 
-  * * * * * cd ~/.dashcore/sentinel && ./venv/bin/python bin/sentinel.py 2>&1 >> sentinel-cron.log
   * * * * * pidof dashd || ~/.dashcore/dashd
 
 Press enter to make sure there is a blank line at the end of the file,


### PR DESCRIPTION
Core v20 won't require sentinel (dashpay/dash#5525) so we can remove reference to it in setup instructions.

<!-- Replace -->
Preview build: https://dash-docs--299.org.readthedocs.build/en/299/
<!-- Replace -->
