### PR TITLE
docs: update platform links in sidebar

### DIFF
--- a/_templates/sidebar-main.html
+++ b/_templates/sidebar-main.html
@@ -84,16 +84,17 @@
         <ul class="nav bd-sidenav">
 
           <li class="toctree-l1"><a class="reference internal"
-              href="https://dashplatform.readme.io/docs/introduction-what-is-dash-platform">Introduction</a></li>
-          <li class="toctree-l1"><a class="reference internal"
-              href="https://dashplatform.readme.io/docs/tutorials-introduction">Tutorials</a>
+              href="https://docs.dash.org/projects/platform/en/stable/docs/intro/what-is-dash-platform.html">Introduction</a>
           </li>
           <li class="toctree-l1"><a class="reference internal"
-              href="https://dashplatform.readme.io/docs/explanation-dapi">Explanations</a></li>
+              href="https://docs.dash.org/projects/platform/en/stable/docs/tutorials/introduction.html">Tutorials</a>
+          </li>
           <li class="toctree-l1"><a class="reference internal"
-              href="https://dashplatform.readme.io/docs/reference-dapi-endpoints">Reference</a></li>
+              href="https://docs.dash.org/projects/platform/en/stable/docs/explanations/dapi.html">Explanations</a></li>
           <li class="toctree-l1"><a class="reference internal"
-              href="https://dashplatform.readme.io/docs/platform-protocol-reference-overview">Platform Protocol</a></li>
+              href="https://docs.dash.org/projects/platform/en/stable/docs/reference/dapi-endpoints.html">Reference</a></li>
+          <li class="toctree-l1"><a class="reference internal"
+              href="https://docs.dash.org/projects/platform/en/stable/docs/protocol-ref/overview.html">Platform Protocol</a></li>
           </li>
 
         </ul>

--- a/conf.py
+++ b/conf.py
@@ -115,6 +115,7 @@ myst_enable_extensions = ["colon_fence"]
 # -- intersphinx configuration -----------------------------------------------
 intersphinx_mapping = {
     "core": ("https://docs.dash.org/projects/core/en/stable/", None),
+    "platform": ("https://docs.dash.org/projects/platform/en/stable/", None),
 }
 
 # We recommend adding the following config value.
@@ -137,7 +138,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "external_links": [
         {"name": "Core docs", "url": "https://docs.dash.org/projects/core/en/stable/docs/index.html"},
-        {"name": "Platform docs", "url": "https://dashplatform.readme.io"},
+        {"name": "Platform docs", "url": "https://docs.dash.org/projects/platform/en/stable/docs/index.html"},
         {"name": "Dash.org", "url": "https://www.dash.org"},
         {"name": "Forum", "url": "https://www.dash.org/forum"},
     ],

--- a/docs/user/introduction/information.rst
+++ b/docs/user/introduction/information.rst
@@ -19,7 +19,7 @@ Official sites
 - **Website:** https://www.dash.org
 - **User documentation:** https://docs.dash.org
 - **Dash Core Documentation:** https://docs.dash.org/core
-- **Dash Platform Documentation:** https://dashplatform.readme.io
+- **Dash Platform Documentation:** https://docs.dash.org/platform
 - **GitHub:** https://github.com/dashpay
 - **GitHub (Evolution):** https://github.com/dashevo
 - **Roadmap:** https://www.dash.org/roadmap/


### PR DESCRIPTION
Switches links from readme.io to docs.dash.org