### PR TITLE
Bump nvm install version to Node LTS

### DIFF
--- a/docs/user/masternodes/setup-evonode.rst
+++ b/docs/user/masternodes/setup-evonode.rst
@@ -233,7 +233,7 @@ dashmate dependencies::
   newgrp docker
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
   source ~/.bashrc
-  nvm install 16
+  nvm install 18
 
 Install dashmate::
 


### PR DESCRIPTION
# Issue

Users that follows documentation step install incorrect Node.Js version which results in `npm WARN EBADENGINE `

Platform supports Node.Js v18+

<!-- Replace -->
Preview build: https://dash-docs--312.org.readthedocs.build/en/312/
<!-- Replace -->
