### PR TITLE
chore: update links to v20.0

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -180,7 +180,7 @@ html_context = {
     # "github_url": "https://github.com", # or your GitHub Enterprise site
     "github_user": "dashpay",
     "github_repo": "docs",
-    "github_version": "19.0.0",
+    "github_version": "20.0.0",
     "doc_path": "",
 }
 

--- a/docs/user/developers/insight.rst
+++ b/docs/user/developers/insight.rst
@@ -32,9 +32,9 @@ dependencies::
 Download and extract the latest version of Dash Core::
 
   cd ~
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-x86_64-linux-gnu.tar.gz
-  tar -xvzf dashcore-19.3.0-x86_64-linux-gnu.tar.gz
-  rm dashcore-19.3.0-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-x86_64-linux-gnu.tar.gz
+  tar -xvzf dashcore-20.0.0-x86_64-linux-gnu.tar.gz
+  rm dashcore-20.0.0-x86_64-linux-gnu.tar.gz
 
 Install `Dashcore Node <https://github.com/dashpay/dashcore-node>`_ and
 create your configuration::
@@ -55,7 +55,7 @@ Change paths in the configuration file as follows::
   nano dashcore-node.json
 
 - Change the value of ``datadir`` to ``../../.dashcore``
-- Change the value of ``exec`` to ``../../dashcore-19.3.0/bin/dashd``
+- Change the value of ``exec`` to ``../../dashcore-20.0.0/bin/dashd``
 - **Optionally** change the value of ``network`` to ``testnet`` if you 
   want to run Insight on testnet
 

--- a/docs/user/masternodes/maintenance.rst
+++ b/docs/user/masternodes/maintenance.rst
@@ -47,7 +47,7 @@ enter the following command, pasting in the address to the latest
 version of Dash Core by right clicking or pressing **Ctrl + V**::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -63,14 +63,14 @@ following keys:
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-19.3.0-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-20.0.0-x86_64-linux-gnu.tar.gz.asc
 
 Extract the compressed archive and copy the new files to the directory::
 
-  tar xfv dashcore-19.3.0-x86_64-linux-gnu.tar.gz
-  cp -f dashcore-19.3.0/bin/dashd ~/.dashcore/
-  cp -f dashcore-19.3.0/bin/dash-cli ~/.dashcore/
+  tar xfv dashcore-20.0.0-x86_64-linux-gnu.tar.gz
+  cp -f dashcore-20.0.0/bin/dashd ~/.dashcore/
+  cp -f dashcore-20.0.0/bin/dash-cli ~/.dashcore/
 
 Restart Dash::
 

--- a/docs/user/masternodes/setup-evonode.rst
+++ b/docs/user/masternodes/setup-evonode.rst
@@ -271,7 +271,7 @@ command, pasting in the address to the latest version of Dash Core by right clic
 or pressing **Ctrl+ V**::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -287,16 +287,16 @@ following keys:
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-19.3.0-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-20.0.0-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive and
 copy the necessary files to the directory::
 
   mkdir ~/.dashcore
-  tar xfv dashcore-19.3.0-x86_64-linux-gnu.tar.gz
-  cp -f dashcore-19.3.0/bin/dashd ~/.dashcore/
-  cp -f dashcore-19.3.0/bin/dash-cli ~/.dashcore/
+  tar xfv dashcore-20.0.0-x86_64-linux-gnu.tar.gz
+  cp -f dashcore-20.0.0/bin/dashd ~/.dashcore/
+  cp -f dashcore-20.0.0/bin/dash-cli ~/.dashcore/
 
 Create a configuration file using the following command::
 

--- a/docs/user/masternodes/setup-testnet.rst
+++ b/docs/user/masternodes/setup-testnet.rst
@@ -655,7 +655,7 @@ and communication relating to the base blockchain. Download Dash Core as
 follows::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-$(uname -m)-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-$(uname -m)-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -667,14 +667,14 @@ team. All releases of Dash are signed using GPG with the following key:
 ::
 
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-$(uname -m)-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-19.3.0-$(uname -m)-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-$(uname -m)-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-20.0.0-$(uname -m)-linux-gnu.tar.gz.asc
 
 Extract the compressed archive and copy the necessary files to the
 directory::
 
-  tar xfv dashcore-19.3.0-$(uname -m)-linux-gnu.tar.gz
-  sudo install -t /usr/local/bin dashcore-19.3.0/bin/*
+  tar xfv dashcore-20.0.0-$(uname -m)-linux-gnu.tar.gz
+  sudo install -t /usr/local/bin dashcore-20.0.0/bin/*
 
 Create a working directory for Dash Core::
 

--- a/docs/user/masternodes/setup.rst
+++ b/docs/user/masternodes/setup.rst
@@ -233,7 +233,7 @@ address to the latest version of Dash Core by right clicking or pressing
 **Ctrl + V**::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -249,16 +249,16 @@ following keys:
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-19.3.0-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-20.0.0-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive and
 copy the necessary files to the directory::
 
   mkdir ~/.dashcore
-  tar xfv dashcore-19.3.0-x86_64-linux-gnu.tar.gz
-  cp -f dashcore-19.3.0/bin/dashd ~/.dashcore/
-  cp -f dashcore-19.3.0/bin/dash-cli ~/.dashcore/
+  tar xfv dashcore-20.0.0-x86_64-linux-gnu.tar.gz
+  cp -f dashcore-20.0.0/bin/dashd ~/.dashcore/
+  cp -f dashcore-20.0.0/bin/dash-cli ~/.dashcore/
 
 Create a configuration file using the following command::
 

--- a/docs/user/mining/p2pool.rst
+++ b/docs/user/mining/p2pool.rst
@@ -112,7 +112,7 @@ address to the latest version of Dash Core by right clicking or pressing
 **Ctrl + V**::
 
   cd ~
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -128,21 +128,21 @@ following keys:
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v19.3.0/dashcore-19.3.0-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-19.3.0-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v20.0.0/dashcore-20.0.0-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-20.0.0-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive,
 copy the necessary files to the directory and set them as executable::
 
   mkdir ~/.dashcore
-  tar xfvz dashcore-19.3.0-x86_64-linux-gnu.tar.gz
-  cp dashcore-19.3.0/bin/dashd .dashcore/
-  cp dashcore-19.3.0/bin/dash-cli .dashcore/
+  tar xfvz dashcore-20.0.0-x86_64-linux-gnu.tar.gz
+  cp dashcore-20.0.0/bin/dashd .dashcore/
+  cp dashcore-20.0.0/bin/dash-cli .dashcore/
 
 Clean up unneeded files::
 
-  rm dashcore-19.3.0-x86_64-linux-gnu.tar.gz
-  rm -r dashcore-19.3.0/
+  rm dashcore-20.0.0-x86_64-linux-gnu.tar.gz
+  rm -r dashcore-20.0.0/
 
 Create a configuration file using the following command::
 

--- a/docs/user/wallets/dashcore/installation-linux.rst
+++ b/docs/user/wallets/dashcore/installation-linux.rst
@@ -61,7 +61,7 @@ download as follows::
 
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import  
-  gpg --verify dashcore-19.3.0-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-20.0.0-x86_64-linux-gnu.tar.gz.asc
 
 .. figure:: img/linux/setup-linux-gpg.png
    :width: 400px
@@ -82,13 +82,13 @@ we will extract the executable file with a graphical user interface
 
 Extract Dash Core as follows::
 
-  tar xzf dashcore-19.3.0-x86_64-linux-gnu.tar.gz
+  tar xzf dashcore-20.0.0-x86_64-linux-gnu.tar.gz
 
-This will create a folder named ``dashcore-19.3.0`` in the current working
+This will create a folder named ``dashcore-20.0.0`` in the current working
 directory. We will now install the executable binaries to
 ``/usr/local/bin`` using the ``install`` command::
 
-  sudo install -m 0755 -o root -g root -t /usr/local/bin dashcore-19.3.0/bin/*
+  sudo install -m 0755 -o root -g root -t /usr/local/bin dashcore-20.0.0/bin/*
 
 Start Dash Core from the terminal with the following command::
   

--- a/docs/user/wallets/dashcore/installation-macos.rst
+++ b/docs/user/wallets/dashcore/installation-macos.rst
@@ -52,7 +52,7 @@ download as follows::
 
   curl https://keybase.io/codablock/pgp_keys.asc | gpg --import
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  gpg --verify dashcore-19.3.0-osx.dmg.asc
+  gpg --verify dashcore-20.0.0-osx.dmg.asc
 
 
 .. figure:: img/linux/setup-linux-gpg.png

--- a/docs/user/wallets/dashcore/installation-windows.rst
+++ b/docs/user/wallets/dashcore/installation-windows.rst
@@ -66,7 +66,7 @@ Import the key files and verify the Key-ID matches the ID above.
 
 Skip any requests to certify the certificate with your own key. Next,
 click **Decrypt/Verify...** and select the detached signature file named
-``dashcore-19.3.0-win64-setup.exe.asc`` in the same folder as the
+``dashcore-20.0.0-win64-setup.exe.asc`` in the same folder as the
 downloaded installer.
 
 .. figure:: img/windows/setup-windows-kleopatra-verify.png
@@ -75,8 +75,8 @@ downloaded installer.
    Selecting the signature file for verification
 
 If you see the first line of the message reads ``Verified
-dashcore-19.3.0-win64-setup.exe with
-dashcore-19.3.0-win64-setup.exe.asc`` then you have an authentic copy
+dashcore-20.0.0-win64-setup.exe with
+dashcore-20.0.0-win64-setup.exe.asc`` then you have an authentic copy
 of Dash Core for Windows.
 
 .. figure:: img/windows/setup-windows-kleopatra-verified.png

--- a/scripts/update-download-links.sh
+++ b/scripts/update-download-links.sh
@@ -2,6 +2,6 @@
 
 # Script to update the download/install related version references when a new
 # Dash Core version is released
-find . -iname "*.rst" -exec sed -i 's~/v19.2.0/dashcore-19.2.0-~/v19.3.0/dashcore-19.3.0-~g' {} +
-find . -iname "*.rst" -exec sed -i 's~dashcore-19.2.0-~dashcore-19.3.0-~g' {} +
-find . -iname "*.rst" -exec sed -i 's~dashcore-19.2.0~dashcore-19.3.0~g' {} +
+find . -iname "*.rst" -exec sed -i 's~/v19.3.0/dashcore-19.3.0-~/v20.0.0/dashcore-20.0.0-~g' {} +
+find . -iname "*.rst" -exec sed -i 's~dashcore-19.3.0-~dashcore-20.0.0-~g' {} +
+find . -iname "*.rst" -exec sed -i 's~dashcore-19.3.0~dashcore-20.0.0~g' {} +


### PR DESCRIPTION
Update download / command references to use v20 instead of v19.

<!-- Replace -->
Preview build: https://dash-docs--315.org.readthedocs.build/en/315/
<!-- Replace -->
(preview link not working due to a webhook migration issue with readthedocs)