### PR TITLE
chore: bump node.js and nvm versions

### DIFF
--- a/docs/user/masternodes/setup-evonode.rst
+++ b/docs/user/masternodes/setup-evonode.rst
@@ -231,9 +231,9 @@ dashmate dependencies::
   curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh
   sudo usermod -aG docker $USER
   newgrp docker
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
   source ~/.bashrc
-  nvm install 18
+  nvm install 20
 
 Install dashmate::
 

--- a/docs/user/masternodes/setup-testnet.rst
+++ b/docs/user/masternodes/setup-testnet.rst
@@ -775,12 +775,12 @@ Next, we will install the Dash Platform services. Start with installing
 JavaScript dependencies::
 
   cd
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
   source ~/.bashrc
-  nvm install 16.20.2
+  nvm install 20
   npm install pm2 -g
 
-Followed by Rust dependencies:: 
+Followed by Rust dependencies::
 
   sudo apt install -y build-essential clang cmake curl g++ gcc gnupg2 libgmp-dev libpython3.10-dev libssl-dev libzmq3-dev lsb-release pkg-config
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -1027,9 +1027,9 @@ directly. Install dependencies if necessary (Docker, NodeJS, NPM, Github
 CLI). Windows, macOS and Linux are supported, the following example
 shows how to install dependencies under Ubuntu 20.04 LTS.::
 
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
   source ~/.bashrc
-  nvm install 16
+  nvm install 20
   curl -fsSL https://get.docker.com -o get-docker.sh && sh ./get-docker.sh
   sudo usermod -aG docker $USER
   newgrp docker

--- a/docs/user/network/dashmate/index.rst
+++ b/docs/user/network/dashmate/index.rst
@@ -60,9 +60,9 @@ Node package
 To install the NodeJS package, it is necessary to install NodeJS first. We recommend
 installing it using `nvm <https://github.com/nvm-sh/nvm#readme>`__::
 
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
   source ~/.bashrc
-  nvm install 18
+  nvm install 20
 
 Once NodeJS has been installed, use npm to install dashmate::
 


### PR DESCRIPTION
# Issue
Bump to the new Node.JS LTS and upgrade NVM install script version

<!-- Replace -->
Preview build: https://dash-docs--320.org.readthedocs.build/en/320/
<!-- Replace -->
