### PR TITLE
docs: update links to platform docs to use latest instead of stable

### DIFF
--- a/_templates/sidebar-main.html
+++ b/_templates/sidebar-main.html
@@ -84,17 +84,17 @@
         <ul class="nav bd-sidenav">
 
           <li class="toctree-l1"><a class="reference internal"
-              href="https://docs.dash.org/projects/platform/en/stable/docs/intro/what-is-dash-platform.html">Introduction</a>
+              href="https://docs.dash.org/projects/platform/en/latest/docs/intro/what-is-dash-platform.html">Introduction</a>
           </li>
           <li class="toctree-l1"><a class="reference internal"
-              href="https://docs.dash.org/projects/platform/en/stable/docs/tutorials/introduction.html">Tutorials</a>
+              href="https://docs.dash.org/projects/platform/en/latest/docs/tutorials/introduction.html">Tutorials</a>
           </li>
           <li class="toctree-l1"><a class="reference internal"
-              href="https://docs.dash.org/projects/platform/en/stable/docs/explanations/dapi.html">Explanations</a></li>
+              href="https://docs.dash.org/projects/platform/en/latest/docs/explanations/dapi.html">Explanations</a></li>
           <li class="toctree-l1"><a class="reference internal"
-              href="https://docs.dash.org/projects/platform/en/stable/docs/reference/dapi-endpoints.html">Reference</a></li>
+              href="https://docs.dash.org/projects/platform/en/latest/docs/reference/dapi-endpoints.html">Reference</a></li>
           <li class="toctree-l1"><a class="reference internal"
-              href="https://docs.dash.org/projects/platform/en/stable/docs/protocol-ref/overview.html">Platform Protocol</a></li>
+              href="https://docs.dash.org/projects/platform/en/latest/docs/protocol-ref/overview.html">Platform Protocol</a></li>
           </li>
 
         </ul>

--- a/conf.py
+++ b/conf.py
@@ -116,7 +116,7 @@ myst_enable_extensions = ["colon_fence"]
 # -- intersphinx configuration -----------------------------------------------
 intersphinx_mapping = {
     "core": ("https://docs.dash.org/projects/core/en/stable/", None),
-    "platform": ("https://docs.dash.org/projects/platform/en/stable/", None),
+    "platform": ("https://docs.dash.org/projects/platform/en/latest/", None),
 }
 
 # We recommend adding the following config value.
@@ -139,7 +139,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "external_links": [
         {"name": "Core docs", "url": "https://docs.dash.org/projects/core/en/stable/docs/index.html"},
-        {"name": "Platform docs", "url": "https://docs.dash.org/projects/platform/en/stable/docs/index.html"},
+        {"name": "Platform docs", "url": "https://docs.dash.org/projects/platform/en/latest/docs/index.html"},
         {"name": "Dash.org", "url": "https://www.dash.org"},
         {"name": "Forum", "url": "https://www.dash.org/forum"},
     ],


### PR DESCRIPTION
Needed to direct to 1.0-dev docs