### PR TITLE
fix: replace dead qr code generator link with new site

### DIFF
--- a/docs/user/developers/integration-apis.rst
+++ b/docs/user/developers/integration-apis.rst
@@ -215,6 +215,6 @@ online and offline.
 - In Dash for iOS, swipe to the left to display the **Receive Dash**
   screen. A QR code and address will appear. You can screenshot this to
   save an image.
-- To generate a QR code from any Dash address, visit `CWA QR Code
-  Generator <https://cwaqrgen.com/dash>`_ and simply paste your Dash
-  address to generate an image.
+- To generate a QR code from any Dash address, visit `QRCode Monkey
+  <https://www.qrcode-monkey.com/#bitcoin>`_, paste your Dash address,
+  and select the Dash cryptocurrency type to generate an image.


### PR DESCRIPTION
This site supports Dash-specific QR code generation (creates a code recognizable to Dash wallet).
![image](https://github.com/dashpay/docs/assets/8145677/4eb88af3-14be-406f-b62a-325e54f8dcf7)


<!-- Replace -->
Preview build: https://dash-docs--352.org.readthedocs.build/en/352/docs/user/developers/integration-apis.html#qr-codes
<!-- Replace -->
