### PR TITLE
chore: placeholder dashmate download link for 1.0.1

### DIFF
--- a/docs/user/network/dashmate/index.rst
+++ b/docs/user/network/dashmate/index.rst
@@ -50,7 +50,7 @@ recommended for mainnet masternodes.
 Debian package
 ^^^^^^^^^^^^^^
 
-Download the dashmate installation package for your architecture from the `GitHub releases
+Download the newest dashmate installation package for your architecture from the `GitHub releases
 page <https://github.com/dashpay/platform/releases/latest>`__::
 
    wget https://github.com/dashpay/platform/releases/download/v1.0.1/dashmate_1.0.1.9ff08df99-1_amd64.deb

--- a/docs/user/network/dashmate/index.rst
+++ b/docs/user/network/dashmate/index.rst
@@ -53,12 +53,12 @@ Debian package
 Download the dashmate installation package for your architecture from the `GitHub releases
 page <https://github.com/dashpay/platform/releases/latest>`__::
 
-   wget https://github.com/dashpay/platform/releases/download/v1.0.0/dashmate_1.0.0.xxxxxxxxx-1_amd64.deb
+   wget https://github.com/dashpay/platform/releases/download/v1.0.0/dashmate_1.0.0.e16c87ae7-1_amd64.deb
 
 Install dashmate using apt::
 
    sudo apt update
-   sudo apt install ./dashmate_1.0.0.xxxxxxxxx-1_amd64.deb
+   sudo apt install ./dashmate_1.0.0.e16c87ae7-1_amd64.deb
 
 Node package
 ^^^^^^^^^^^^

--- a/docs/user/network/dashmate/index.rst
+++ b/docs/user/network/dashmate/index.rst
@@ -53,12 +53,12 @@ Debian package
 Download the dashmate installation package for your architecture from the `GitHub releases
 page <https://github.com/dashpay/platform/releases/latest>`__::
 
-   wget https://github.com/dashpay/platform/releases/download/v0.25.22/dashmate_0.25.22.b143aee50-1_amd64.deb
+   wget https://github.com/dashpay/platform/releases/download/v1.0.0/dashmate_1.0.0.xxxxxxxxx-1_amd64.deb
 
 Install dashmate using apt::
 
    sudo apt update
-   sudo apt install ./dashmate_0.25.22.b143aee50-1_amd64.deb
+   sudo apt install ./dashmate_1.0.0.xxxxxxxxx-1_amd64.deb
 
 Node package
 ^^^^^^^^^^^^

--- a/docs/user/network/dashmate/index.rst
+++ b/docs/user/network/dashmate/index.rst
@@ -53,12 +53,12 @@ Debian package
 Download the dashmate installation package for your architecture from the `GitHub releases
 page <https://github.com/dashpay/platform/releases/latest>`__::
 
-   wget https://github.com/dashpay/platform/releases/download/v1.0.0/dashmate_1.0.0.e16c87ae7-1_amd64.deb
+   wget https://github.com/dashpay/platform/releases/download/v1.0.1/dashmate_1.0.1.9ff08df99-1_amd64.deb
 
 Install dashmate using apt::
 
    sudo apt update
-   sudo apt install ./dashmate_1.0.0.e16c87ae7-1_amd64.deb
+   sudo apt install ./dashmate_1.0.1.9ff08df99-1_amd64.deb
 
 Node package
 ^^^^^^^^^^^^


### PR DESCRIPTION
Don't merge - update with the actual dashmate v1 link which won't be available until it is released on GitHub

<!-- Replace -->
Preview build: https://dash-docs--357.org.readthedocs.build/en/357/
<!-- Replace -->
