### PR TITLE
chore: release updates

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -184,7 +184,7 @@ html_context = {
     # "github_url": "https://github.com", # or your GitHub Enterprise site
     "github_user": "dashpay",
     "github_repo": "docs",
-    "github_version": "20.1.0",
+    "github_version": "21.0.0",
     "doc_path": "",
 }
 

--- a/docs/user/masternodes/setup-evonode.rst
+++ b/docs/user/masternodes/setup-evonode.rst
@@ -243,9 +243,9 @@ dashmate dependencies::
 Download the dashmate installation package for your CPU architecture from the `GitHub releases page
 <https://github.com/dashpay/platform/releases/latest>`__ and install it using apt::
 
-   wget https://github.com/dashpay/platform/releases/download/v0.25.22/dashmate_0.25.22.b143aee50-1_amd64.deb
+   wget https://github.com/dashpay/platform/releases/download/v1.0.1/dashmate_1.0.1.9ff08df99-1_amd64.deb
    sudo apt update
-   sudo apt install ./dashmate_0.25.22.b143aee50-1_amd64.deb
+   sudo apt install ./dashmate_1.0.1.9ff08df99-1_amd64.deb
 
 Alternative installation options are available on the :hoverxref:`dashmate page
 <dashmate-install>`.


### PR DESCRIPTION
Update dashmate download location in another place. Also, change the default docs version so "Edit on GitHub" link directs to the right branch.

<!-- Replace -->
Preview build: https://dash-docs--359.org.readthedocs.build/en/359/
<!-- Replace -->
