### PR TITLE
docs: dashmate update note

### DIFF
--- a/docs/user/network/dashmate/index.rst
+++ b/docs/user/network/dashmate/index.rst
@@ -354,6 +354,11 @@ masternode as follows::
   dashmate update
   dashmate start
 
+.. note:: To update to a new version of dashmate or to a new major version of
+   Core or Platform, it is necessary to download and install the newer version
+   of dashmate. Refer to the :ref:`dashmate install section <dashmate-install>` for
+   details.
+
 Additional Information
 ======================
 


### PR DESCRIPTION
Add note to clarify that dashmate update cannot be used to install newer versions of dashmate or major version updates

<!-- Replace -->
Preview build: https://dash-docs--360.org.readthedocs.build/en/360/
<!-- Replace -->
