### PR TITLE
docs: temporary remove `--keep-data` from v0.25 upgrade path

### DIFF
--- a/docs/user/masternodes/dashmate-upgrade-v0_25.rst
+++ b/docs/user/masternodes/dashmate-upgrade-v0_25.rst
@@ -24,7 +24,7 @@ Install the new dashmate version
 
 3. Reset previous services to ensure compatibility with the new version::
    
-     dashmate reset
+     dashmate reset --platform
 
 .. _evonode-setup-ssl:
 

--- a/docs/user/masternodes/dashmate-upgrade-v0_25.rst
+++ b/docs/user/masternodes/dashmate-upgrade-v0_25.rst
@@ -22,10 +22,9 @@ Install the new dashmate version
    <https://github.com/dashpay/platform/releases/latest>`__. For more details, refer to the
    :ref:`install instructions <evonode-setup-install-dashmate>`.
 
-3. Reset previous services to ensure compatibility with the new version. Use ``--keep-data`` so the
-   existing blockchain is retained::
+3. Reset previous services to ensure compatibility with the new version::
    
-     dashmate reset --keep-data
+     dashmate reset
 
 .. _evonode-setup-ssl:
 


### PR DESCRIPTION
we want to return it back when platform is activated

<!-- Replace -->
Preview build: https://dash-docs--378.org.readthedocs.build/en/378/
<!-- Replace -->
