### PR TITLE
docs: temporary remove `--keep-data` from v1 upgrade path

### DIFF
--- a/docs/user/masternodes/dashmate-upgrade-v1.rst
+++ b/docs/user/masternodes/dashmate-upgrade-v1.rst
@@ -25,7 +25,7 @@ Install the new dashmate version
 
 3. Reset previous services to ensure compatibility with the new version::
    
-     dashmate reset
+     dashmate reset --platform
 
 4. Update services::
    

--- a/docs/user/masternodes/dashmate-upgrade-v1.rst
+++ b/docs/user/masternodes/dashmate-upgrade-v1.rst
@@ -23,10 +23,9 @@ Install the new dashmate version
    <https://github.com/dashpay/platform/releases/latest>`__. For more details, refer to the
    :ref:`install instructions <evonode-setup-install-dashmate>`.
 
-3. Reset previous services to ensure compatibility with the new version. Use ``--keep-data`` so the
-   existing blockchain is retained::
+3. Reset previous services to ensure compatibility with the new version::
    
-     dashmate reset --keep-data
+     dashmate reset
 
 4. Update services::
    


### PR DESCRIPTION
we want to return it back when platform is activated

<!-- Replace -->
Preview build: https://dash-docs--379.org.readthedocs.build/en/379/
<!-- Replace -->
