### PR TITLE
chore: link to Dash Core v21.1.1 binaries

### DIFF
--- a/docs/user/developers/insight.rst
+++ b/docs/user/developers/insight.rst
@@ -32,9 +32,9 @@ dependencies::
 Download and extract the latest version of Dash Core::
 
   cd ~
-  wget https://github.com/dashpay/dash/releases/download/v21.1.0/dashcore-21.1.0-x86_64-linux-gnu.tar.gz
-  tar -xvzf dashcore-21.1.0-x86_64-linux-gnu.tar.gz
-  rm dashcore-21.1.0-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v21.1.1/dashcore-21.1.1-x86_64-linux-gnu.tar.gz
+  tar -xvzf dashcore-21.1.1-x86_64-linux-gnu.tar.gz
+  rm dashcore-21.1.1-x86_64-linux-gnu.tar.gz
 
 Install `Dashcore Node <https://github.com/dashpay/dashcore-node>`_ and
 create your configuration::
@@ -55,7 +55,7 @@ Change paths in the configuration file as follows::
   nano dashcore-node.json
 
 - Change the value of ``datadir`` to ``../../.dashcore``
-- Change the value of ``exec`` to ``../../dashcore-21.1.0/bin/dashd``
+- Change the value of ``exec`` to ``../../dashcore-21.1.1/bin/dashd``
 - **Optionally** change the value of ``network`` to ``testnet`` if you 
   want to run Insight on testnet
 

--- a/docs/user/masternodes/maintenance.rst
+++ b/docs/user/masternodes/maintenance.rst
@@ -47,7 +47,7 @@ enter the following command, pasting in the address to the latest
 version of Dash Core by right clicking or pressing **Ctrl + V**::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v21.1.0/dashcore-21.1.0-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v21.1.1/dashcore-21.1.1-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -60,14 +60,14 @@ following key:
 ::
 
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v21.1.0/dashcore-21.1.0-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-21.1.0-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v21.1.1/dashcore-21.1.1-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-21.1.1-x86_64-linux-gnu.tar.gz.asc
 
 Extract the compressed archive and copy the new files to the directory::
 
-  tar xfv dashcore-21.1.0-x86_64-linux-gnu.tar.gz
-  cp -f dashcore-21.1.0/bin/dashd ~/.dashcore/
-  cp -f dashcore-21.1.0/bin/dash-cli ~/.dashcore/
+  tar xfv dashcore-21.1.1-x86_64-linux-gnu.tar.gz
+  cp -f dashcore-21.1.1/bin/dashd ~/.dashcore/
+  cp -f dashcore-21.1.1/bin/dash-cli ~/.dashcore/
 
 Restart Dash::
 

--- a/docs/user/masternodes/setup.rst
+++ b/docs/user/masternodes/setup.rst
@@ -231,7 +231,7 @@ address to the latest version of Dash Core by right clicking or pressing
 **Ctrl + V**::
 
   cd /tmp
-  wget https://github.com/dashpay/dash/releases/download/v21.1.0/dashcore-21.1.0-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v21.1.1/dashcore-21.1.1-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -244,16 +244,16 @@ following key:
 ::
 
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v21.1.0/dashcore-21.1.0-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-21.1.0-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v21.1.1/dashcore-21.1.1-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-21.1.1-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive and
 copy the necessary files to the directory::
 
   mkdir ~/.dashcore
-  tar xfv dashcore-21.1.0-x86_64-linux-gnu.tar.gz
-  cp -f dashcore-21.1.0/bin/dashd ~/.dashcore/
-  cp -f dashcore-21.1.0/bin/dash-cli ~/.dashcore/
+  tar xfv dashcore-21.1.1-x86_64-linux-gnu.tar.gz
+  cp -f dashcore-21.1.1/bin/dashd ~/.dashcore/
+  cp -f dashcore-21.1.1/bin/dash-cli ~/.dashcore/
 
 Create a configuration file using the following command::
 

--- a/docs/user/mining/p2pool.rst
+++ b/docs/user/mining/p2pool.rst
@@ -112,7 +112,7 @@ address to the latest version of Dash Core by right clicking or pressing
 **Ctrl + V**::
 
   cd ~
-  wget https://github.com/dashpay/dash/releases/download/v21.1.0/dashcore-21.1.0-x86_64-linux-gnu.tar.gz
+  wget https://github.com/dashpay/dash/releases/download/v21.1.1/dashcore-21.1.1-x86_64-linux-gnu.tar.gz
 
 Verify the authenticity of your download by checking its detached
 signature against the public key published by the Dash Core development
@@ -125,21 +125,21 @@ following key:
 ::
 
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  wget https://github.com/dashpay/dash/releases/download/v21.1.0/dashcore-21.1.0-x86_64-linux-gnu.tar.gz.asc
-  gpg --verify dashcore-21.1.0-x86_64-linux-gnu.tar.gz.asc
+  wget https://github.com/dashpay/dash/releases/download/v21.1.1/dashcore-21.1.1-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-21.1.1-x86_64-linux-gnu.tar.gz.asc
 
 Create a working directory for Dash, extract the compressed archive,
 copy the necessary files to the directory and set them as executable::
 
   mkdir ~/.dashcore
-  tar xfvz dashcore-21.1.0-x86_64-linux-gnu.tar.gz
-  cp dashcore-21.1.0/bin/dashd .dashcore/
-  cp dashcore-21.1.0/bin/dash-cli .dashcore/
+  tar xfvz dashcore-21.1.1-x86_64-linux-gnu.tar.gz
+  cp dashcore-21.1.1/bin/dashd .dashcore/
+  cp dashcore-21.1.1/bin/dash-cli .dashcore/
 
 Clean up unneeded files::
 
-  rm dashcore-21.1.0-x86_64-linux-gnu.tar.gz
-  rm -r dashcore-21.1.0/
+  rm dashcore-21.1.1-x86_64-linux-gnu.tar.gz
+  rm -r dashcore-21.1.1/
 
 Create a configuration file using the following command::
 

--- a/docs/user/wallets/dashcore/installation-linux.rst
+++ b/docs/user/wallets/dashcore/installation-linux.rst
@@ -58,7 +58,7 @@ Open a terminal, import the key and verify the authenticity of your
 download as follows::
 
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  gpg --verify dashcore-21.1.0-x86_64-linux-gnu.tar.gz.asc
+  gpg --verify dashcore-21.1.1-x86_64-linux-gnu.tar.gz.asc
 
 .. figure:: img/linux/setup-linux-gpg.png
    :width: 400px
@@ -74,7 +74,7 @@ authentic copy of Dash Core for Linux.
    verification output by signing the imported key before verifying::
    
       gpg --quick-lsign-key "29590362EC878A81FD3C202B52527BEDABE87984"
-      gpg --verify dashcore-21.1.0-x86_64-linux-gnu.tar.gz.asc
+      gpg --verify dashcore-21.1.1-x86_64-linux-gnu.tar.gz.asc
 
 Extracting Dash Core
 ----------------------
@@ -87,13 +87,13 @@ we will extract the executable file with a graphical user interface
 
 Extract Dash Core as follows::
 
-  tar xzf dashcore-21.1.0-x86_64-linux-gnu.tar.gz
+  tar xzf dashcore-21.1.1-x86_64-linux-gnu.tar.gz
 
-This will create a folder named ``dashcore-21.1.0`` in the current working
+This will create a folder named ``dashcore-21.1.1`` in the current working
 directory. We will now install the executable binaries to
 ``/usr/local/bin`` using the ``install`` command::
 
-  sudo install -m 0755 -o root -g root -t /usr/local/bin dashcore-21.1.0/bin/*
+  sudo install -m 0755 -o root -g root -t /usr/local/bin dashcore-21.1.1/bin/*
 
 Start Dash Core from the terminal with the following command::
   

--- a/docs/user/wallets/dashcore/installation-macos.rst
+++ b/docs/user/wallets/dashcore/installation-macos.rst
@@ -49,7 +49,7 @@ Open a terminal, import the keys and verify the authenticity of your
 download as follows::
 
   curl https://keybase.io/pasta/pgp_keys.asc | gpg --import
-  gpg --verify dashcore-21.1.0-osx.dmg.asc
+  gpg --verify dashcore-21.1.1-osx.dmg.asc
 
 
 .. figure:: img/linux/setup-linux-gpg.png
@@ -66,7 +66,7 @@ authentic copy of Dash Core for macOS.
    verification output by signing the imported key before verifying::
    
       gpg --quick-lsign-key "29590362EC878A81FD3C202B52527BEDABE87984"
-      gpg --verify dashcore-21.1.0-x86_64-linux-gnu.tar.gz.asc
+      gpg --verify dashcore-21.1.1-x86_64-linux-gnu.tar.gz.asc
 
 Installing Dash Core
 --------------------

--- a/docs/user/wallets/dashcore/installation-windows.rst
+++ b/docs/user/wallets/dashcore/installation-windows.rst
@@ -64,7 +64,7 @@ Import the key file and verify the Key-ID matches the ID above.
 
 Skip any requests to certify the certificate with your own key. Next,
 click **Decrypt/Verify...** and select the detached signature file named
-``dashcore-21.1.0-win64-setup.exe.asc`` in the same folder as the
+``dashcore-21.1.1-win64-setup.exe.asc`` in the same folder as the
 downloaded installer.
 
 .. figure:: img/windows/setup-windows-kleopatra-verify.png
@@ -73,8 +73,8 @@ downloaded installer.
    Selecting the signature file for verification
 
 If you see the first line of the message reads ``Verified
-dashcore-21.1.0-win64-setup.exe with
-dashcore-21.1.0-win64-setup.exe.asc`` then you have an authentic copy
+dashcore-21.1.1-win64-setup.exe with
+dashcore-21.1.1-win64-setup.exe.asc`` then you have an authentic copy
 of Dash Core for Windows.
 
 .. figure:: img/windows/setup-windows-kleopatra-verified.png

--- a/scripts/update-download-links.sh
+++ b/scripts/update-download-links.sh
@@ -4,8 +4,8 @@
 # Dash Core version is released
 
 # Define old and new version variables
-OLD_VERSION="21.0.2"
-NEW_VERSION="21.1.0"
+OLD_VERSION="21.1.0"
+NEW_VERSION="21.1.1"
 
 git checkout -b v$NEW_VERSION-links
 


### PR DESCRIPTION
Dash Core v21.1.1 has been released: https://github.com/dashpay/dash/releases/tag/v21.1.1