### PR TITLE
ci: run core and dashmate update daily

### DIFF
--- a/.github/workflows/core-download-update.yml
+++ b/.github/workflows/core-download-update.yml
@@ -4,6 +4,8 @@ on:
   repository_dispatch:
     types: [release_published]
   workflow_dispatch:  # This allows the workflow to be triggered manually
+  schedule: # Run daily at midnight UTC
+    - cron: 0 0 * * *
 
 jobs:
   update-core-download-links:

--- a/.github/workflows/dashmate-update.yml
+++ b/.github/workflows/dashmate-update.yml
@@ -4,6 +4,8 @@ on:
   repository_dispatch:
     types: [release_published]
   workflow_dispatch:  # This allows the workflow to be triggered manually
+  schedule: # Run daily at midnight UTC
+    - cron: 0 0 * * *  
 
 jobs:
   update-dashmate-version:


### PR DESCRIPTION
Automatically check if Core or Platform have had releases and open update PRs.
Note: this won't check for an already open PR, so it will probably open 1 per day until one of them is merged.