### PR TITLE
docs: update crowdnode fees

### DIFF
--- a/docs/user/masternodes/hosting.rst
+++ b/docs/user/masternodes/hosting.rst
@@ -34,7 +34,9 @@ https://crowdnode.io
 
 - Operated by: CrowdNode ApS
 - Services: Hosting, Shares
-- Cost: 15% of masternode payments
+- Cost:
+    * 35% of trusted masternode/evonode payments
+    * 20% of trustless masternode payments
 - `Site <https://crowdnode.io>`__
 - `Email <hello@crowdnode.io>`__
 


### PR DESCRIPTION
Crowdnode has changed their fees. They do 20% on Trustless and 35% on Trusted MN/EVOs.

Thanks for noticing @splawik21 :+1: 

<!-- Replace -->
Preview build: https://dash-docs--410.org.readthedocs.build/en/410/docs/user/masternodes/hosting.html#crowdnode
<!-- Replace -->
