### PR TITLE
feat: add alternate analytics config

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -98,6 +98,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx_copybutton',
     'sphinx_design',
+    'sphinxcontrib.googleanalytics',
     'sphinx.ext.intersphinx',
 ]
 
@@ -272,6 +273,11 @@ texinfo_documents = [
      author, 'Dash', 'A revolutionary digital money system, Dash is Digital Cash',
      'Miscellaneous'),
 ]
+
+# -- Google analytics config ----------------------------------------------
+
+googleanalytics_id = 'G-7E5054FV6E'
+googleanalytics_enabled = True
 
 def setup(app):
     app.add_js_file('js/lang.js')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Babel==2.16.0
 myst-parser==2.0.0
 pydata-sphinx-theme==0.14.4
 sphinx==7.2.6
+sphinxcontrib-googleanalytics==0.4
 sphinx-copybutton==0.5.2
 sphinx-hoverxref==1.3.0
 sphinx_design==0.5.0


### PR DESCRIPTION
Readthedocs removed their analytics integration (see https://github.com/readthedocs/readthedocs.org/issues/9530#issuecomment-2233541583). This PR introducs use of an addon to re-enable that capability.