### PR TITLE
chore: update hoverxref dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pydata-sphinx-theme==0.14.4
 sphinx==7.2.6
 sphinxcontrib-googleanalytics==0.4
 sphinx-copybutton==0.5.2
-sphinx-hoverxref==1.3.0
+sphinx-hoverxref==1.4.2
 sphinx_design==0.5.0
 jinja2==3.1.3


### PR DESCRIPTION
Required due to a deprecation: https://about.readthedocs.com/blog/2024/11/embed-api-v2-deprecated/