### PR TITLE
chore: update evo tool download links for 0.4.0

### DIFF
--- a/.github/workflows/evo-tool-download-update.yml
+++ b/.github/workflows/evo-tool-download-update.yml
@@ -1,0 +1,27 @@
+name: Update Dash Evo Tool download links
+
+on:
+  repository_dispatch:
+    types: [release_published]
+  workflow_dispatch:  # This allows the workflow to be triggered manually
+  schedule: # Run daily at midnight UTC
+    - cron: 0 0 * * *
+
+jobs:
+  update-evo-tool-download-links:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout this repository
+      uses: actions/checkout@v4
+
+    - name: Run evo tool download link update script
+      run: "${GITHUB_WORKSPACE}/scripts/evo-tool-download-link-update.sh"
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v6
+      with:
+        branch: update-docs/${{ github.sha }}
+        title: "chore: update evo tool download links to latest version"
+        body: |
+          This PR updates download links in the documentation to use the latest Dash Evo Tool version.

--- a/docs/user/network/dash-evo-tool/index.rst
+++ b/docs/user/network/dash-evo-tool/index.rst
@@ -25,11 +25,11 @@ Linux, MacOS, or Windows packages are available on the `GitHub releases page
 <https://github.com/dashpay/dash-evo-tool/releases/latest>`__. Download the zip file for your
 Operating System, then unzip the downloaded file:
 
-* `Windows <https://github.com/dashpay/dash-evo-tool/releases/download/v0.3.1/dash-evo-tool-windows.zip>`_
-* `Mac (ARM m1-m4) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.3.1/dash-evo-tool-arm64-mac.zip>`_
-* `Mac (x86) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.3.1/dash-evo-tool-x86_64-mac.zip>`_
-* `Linux (x86) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.3.1/dash-evo-tool-x86_64-linux.zip>`_
-* `Linux (ARM) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.3.1/dash-evo-tool-arm64-linux.zip>`_ 
+* `Windows <https://github.com/dashpay/dash-evo-tool/releases/download/v0.4.0/dash-evo-tool-windows.zip>`_
+* `Mac (ARM m1-m4) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.4.0/dash-evo-tool-arm64-mac.zip>`_
+* `Mac (x86) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.4.0/dash-evo-tool-x86_64-mac.zip>`_
+* `Linux (x86) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.4.0/dash-evo-tool-x86_64-linux.zip>`_
+* `Linux (ARM) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.4.0/dash-evo-tool-arm64-linux.zip>`_ 
 
 .. _evo-tool-configure:
 

--- a/scripts/evo-tool-download-link-update.sh
+++ b/scripts/evo-tool-download-link-update.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Script to update the download/install related version references when a new
+# Dash Evo Tool version is released
+
+# Command to get latest Dash Evo Tool tag name
+NEW_VERSION=$(curl -s \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/dashpay/dash-evo-tool/releases/latest | \
+  jq -r '.tag_name' | sed 's/^v//')
+
+if [[ $? -ne 0 || -z "$NEW_VERSION" ]]; then
+  echo "Error: Unexpected response when retrieving the current version. Received: $NEW_VERSION"
+else
+  # Print the extracted values (for verification)
+  echo "Extracted Version: $NEW_VERSION"
+  # git checkout -b v$NEW_VERSION-links # Uncomment to use locally
+
+  # Use the variables in the find/sed commands
+  find . -iname "*.rst" -exec sed -i "s~https://github\.com/dashpay/dash-evo-tool/releases/download/v[0-9]\+\.[0-9]\+\.[0-9]\+~https://github.com/dashpay/dash-evo-tool/releases/download/v${NEW_VERSION}~g" {} +
+
+  echo "Dash Evo Tool version updated to ${NEW_VERSION} in documentation"
+fi


### PR DESCRIPTION
Update download links and add a script/GH action to create PRs automatically when new versions are released.

<!-- Replace -->
Preview build: https://dash-docs--432.org.readthedocs.build/en/432/
<!-- Replace -->
