### PR TITLE
docs: add note about cpu arch

### DIFF
--- a/docs/user/masternodes/understanding.rst
+++ b/docs/user/masternodes/understanding.rst
@@ -419,6 +419,10 @@ Evonodes
 Evonodes have higher hardware requirements since they host Dash Platform services along with Dash
 Core. To support the network effectively, the following requirements are recommended:
 
+.. note::
+
+  Intel CPUs should be `Haswell architecture <https://en.wikipedia.org/wiki/Haswell_(microarchitecture)>`_ or newer
+
 +---------+------------------+
 |         | Recommended      |
 +=========+==================+


### PR DESCRIPTION
Evonodes require Haswell architecture at a minimum if using an Intel CPU

<!-- Replace -->
Preview build: https://dash-docs--436.org.readthedocs.build/en/436/docs/user/masternodes/understanding.html#evonodes
<!-- Replace -->
