### PR TITLE
build: exclude core docs from transifex for now

### DIFF
--- a/docs/core/api/remote-procedure-calls-raw-transactions.md
+++ b/docs/core/api/remote-procedure-calls-raw-transactions.md
@@ -1205,14 +1205,14 @@ _Result (if verbose=`false`)---the serialized transactions_
 | Name     | Type         | Presence                | Description |
 | -------- | ------------ | ----------------------- | ----------- |
 | `result` | object | Required<br>(exactly 1) | If the transaction was found, this will be an object containing the serialized transaction encoded as hex. |
-|→<br>TXID / Raw tx | string:string | Required<br>(1 or more) | A key/value pair with the transaction ID (key) and raw transaction data (value). See the [`getrawtransaction` RPC](../api/remote-procedure-calls-raw-transactions.md#rpc-raw-txs-getrawtx-hex) for an example of the hex transaction data. |
+|→<br>TXID / Raw tx | string:string | Required<br>(1 or more) | A key/value pair with the transaction ID (key) and raw transaction data (value). See the [`getrawtransaction` RPC](../api/remote-procedure-calls-raw-transactions.md#getrawtransaction) for an example of the hex transaction data. |
 
 _Result (if verbose=`true`)---the decoded transactions_
 
 | Name                        | Type           | Presence                | Description |
 | --------------------------- | -------------- | ----------------------- | ----------- |
 | `result`                    | object         | Required<br>(exactly 1) | If the transaction was found, this will be an object describing it |
-|→<br>TXID / Decoded tx | string:string | Required<br>(1 or more) | A key/value pair with the transaction ID (key) and decoded transaction data represented in JSON (value). See the [`getrawtransaction` RPC](../api/remote-procedure-calls-raw-transactions.md#rpc-raw-txs-getrawtx-decoded) for an example of the decoded transaction data. |
+|→<br>TXID / Decoded tx | string:string | Required<br>(1 or more) | A key/value pair with the transaction ID (key) and decoded transaction data represented in JSON (value). See the [`getrawtransaction` RPC](../api/remote-procedure-calls-raw-transactions.md#getrawtransaction) for an example of the decoded transaction data. |
 
 _Examples from Dash Core 20.1.0_
 

--- a/docs/core/guide/transactions-transaction-fees-and-change.md
+++ b/docs/core/guide/transactions-transaction-fees-and-change.md
@@ -6,7 +6,7 @@
 
 # Transaction Fees and Change
 
-Transactions pay fees based on the total byte size of the signed transaction. Fees per byte are calculated based on current demand for space in mined blocks with fees rising as demand increases.  The [transaction fee](../resources/glossary.md#transaction-fee) is split between the miner (25%) and masternode (75%), as explained in the [block reward allocation section](../../user/introduction/features.rst#block-reward-allocation). It is ultimately up to each [miner](../resources/glossary.md#miner) to choose the minimum transaction fee they will accept.
+Transactions pay fees based on the total byte size of the signed transaction. Fees per byte are calculated based on current demand for space in mined blocks with fees rising as demand increases.  The [transaction fee](../resources/glossary.md#transaction-fee) is split between the miner (25%) and masternode (75%), as explained in the [block reward allocation section](../../user/introduction/features.rst). It is ultimately up to each [miner](../resources/glossary.md#miner) to choose the minimum transaction fee they will accept.
 
 All transactions are prioritized based on their fee per byte, with higher-paying transactions being added in sequence until all of the available space is filled.
 

--- a/transifex/README.md
+++ b/transifex/README.md
@@ -1,8 +1,7 @@
 # Transifex
 
-Transifex is used to support multiple languages. The scripts in this folder
-assist with pushing data for translators to Transifex and retrieving translated
-information.
+Transifex is used to support multiple languages. The scripts in this folder assist with pushing data
+for translators to Transifex and retrieving translated information.
 
 ## Install required packages
 
@@ -21,17 +20,17 @@ curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bas
 
 ## Set webhook variables
 
-The `build.sh` script requires Transifex webhook token and URL values. These
-should be defined in a `.env` file. See [.env.example](.env.example) for an
-example of the format.
+The `build.sh` script requires Transifex webhook token and URL values. These should be defined in a
+`.env` file. See [.env.example](.env.example) for an example of the format.
 
 ## Usage
 
-Using the scripts requires adding a Transifex API token to an account that has
-access to the project as mention in the [Transifex client documentation](https://docs.transifex.com/client/introduction#authenticating).
+Using the scripts requires adding a Transifex API token to an account that has access to the project
+as mention in the [Transifex client
+documentation](https://docs.transifex.com/client/introduction#authenticating).
 
-It is also necessary to add authorization information in a `.transifexrc` file
-as shown in this example:
+It is also necessary to add authorization information in a `.transifexrc` file as shown in this
+example:
 
 ```text
 [https://www.transifex.com]
@@ -49,8 +48,8 @@ Run the following from the root of the project to upload to Transifex:
 ./transifex/pushtx.sh
 ```
 
-**Note**: do not commit the *.po file changes created by the pushtx script. Those files should only be
-committed after [pulling the latest changes](#to-retrieve-from-transifex).
+**Note**: do not commit the *.po file changes created by the pushtx script. Those files should only
+be committed after [pulling the latest changes](#to-retrieve-from-transifex).
 
 ### To retrieve from Transifex
 
@@ -62,8 +61,8 @@ Next run the following to retrieve the translation updates:
 
 ### To build localized sites
 
-Make sure the webhook variables are accessible. Run the following in the folder
-containing your `.env` file:
+Make sure the webhook variables are accessible. Run the following in the folder containing your
+`.env` file:
 
 ``` bash
 source .env
@@ -77,8 +76,8 @@ Next run the following to trigger builds for each language on ReadTheDocs:
 
 ### To check build status for localized sites
 
-Make sure the [token](https://docs.readthedocs.io/en/stable/api/v3.html#token) variable is accessible. Run the following in the folder containing your `.env`
-file:
+Make sure the [token](https://docs.readthedocs.io/en/stable/api/v3.html#token) variable is
+accessible. Run the following in the folder containing your `.env` file:
 
 ``` bash
 source .env

--- a/transifex/README.md
+++ b/transifex/README.md
@@ -3,6 +3,10 @@
 Transifex is used to support multiple languages. The scripts in this folder assist with pushing data
 for translators to Transifex and retrieving translated information.
 
+**Note**: Currently only user docs (docs/user directory) are translated. Core developer docs were
+integrated with this repository when Dash Core v22.0 was released, but they are excluded from
+translation.
+
 ## Install required packages
 
 Install the [sphinx-intl](https://pypi.org/project/sphinx-intl/) utility.

--- a/transifex/pushtx.sh
+++ b/transifex/pushtx.sh
@@ -12,6 +12,10 @@ make gettext 2>&1 | tee /tmp/makelog_$$.log
 if [ $PIPESTATUS -ne 0 ]; then echo "make failed, bailing out...";exit 1 ;fi
 grep ": WARNING: " /tmp/makelog_$$.log
 if [ $? -eq 0 ]; then echo "make issued a WARNING, bailing out...";exit 2;fi
+
+# Remove gettext files and directories for docs/core
+rm -r _build/gettext/docs/core
+
 # Restore the original docs/core/dips/README.md from git
 git checkout -- docs/core/dips/README.md
 

--- a/transifex/pushtx.sh
+++ b/transifex/pushtx.sh
@@ -3,10 +3,8 @@
 # Set to the dashpay/docs branch containing the version to update
 DOC_VERSION=master
 
-# Checkout correct branch and pull changes
-git fetch
-git checkout $DOC_VERSION
-git pull upstream $DOC_VERSION
+# Temporarily replace docs/core/dips/README.md to avoid warnings
+echo "# Dash Improvement Proposals (DIPs)" > docs/core/dips/README.md
 
 # Make files needed by sphinx-intl
 rm -r _build
@@ -14,6 +12,8 @@ make gettext 2>&1 | tee /tmp/makelog_$$.log
 if [ $PIPESTATUS -ne 0 ]; then echo "make failed, bailing out...";exit 1 ;fi
 grep ": WARNING: " /tmp/makelog_$$.log
 if [ $? -eq 0 ]; then echo "make issued a WARNING, bailing out...";exit 2;fi
+# Restore the original docs/core/dips/README.md from git
+git checkout -- docs/core/dips/README.md
 
 # Update files for all languages
 sphinx-intl update -p _build/gettext -l de -l pt -l ko -l el -l ar -l ru -l zh_CN -l fr -l es -l ja -l vi -l zh_TW -l it -l tl

--- a/transifex/pushtx.sh
+++ b/transifex/pushtx.sh
@@ -3,6 +3,11 @@
 # Set to the dashpay/docs branch containing the version to update
 DOC_VERSION=master
 
+# Checkout correct branch and pull changes
+git fetch
+git checkout $DOC_VERSION
+git pull upstream $DOC_VERSION
+
 # Temporarily replace docs/core/dips/README.md to avoid warnings
 echo "# Dash Improvement Proposals (DIPs)" > docs/core/dips/README.md
 


### PR DESCRIPTION
They weren't there prior to the integration of Core / User docs. Leaving as-is for now to avoid a massive increase in pages for translation.

<!-- Replace -->
Preview build: https://dash-docs--441.org.readthedocs.build/en/441/
<!-- Replace -->
