### PR TITLE
feat: selectively hide language selector

### DIFF
--- a/_static/js/lang.js
+++ b/_static/js/lang.js
@@ -3,20 +3,16 @@ $(document).ready(function() {
 	$('#langselect').val(DOCUMENTATION_OPTIONS['LANGUAGE']);
 
 	// Define paths where the language selector should be hidden
-	var excludedPaths = [
+	var excludePattern = [
 		"/docs/core/"
 	];
 
 	// Get the current path of the page
 	var pagePath = $(location).attr("pathname");
 	console.log(pagePath)
+	// Check if the current page path contains the exclude pattern
+	var shouldHideLangSelector = pagePath.includes(excludePattern);
 
-	// Check if the current page path starts with any excluded path
-	var shouldHideLangSelector = excludedPaths.some(function(basePath) {
-		return pagePath.startsWith(basePath);
-	});
-
-	// Hide the language selector if the page falls under the excluded paths
 	if (shouldHideLangSelector) {
 		$('#langselect').hide();
 	} else {

--- a/_static/js/lang.js
+++ b/_static/js/lang.js
@@ -1,6 +1,27 @@
 $(document).ready(function() {
 	/* Select current language */
 	$('#langselect').val(DOCUMENTATION_OPTIONS['LANGUAGE']);
+
+	// Define paths where the language selector should be hidden
+	var excludedPaths = [
+		"/docs/core/"
+	];
+
+	// Get the current path of the page
+	var pagePath = $(location).attr("pathname");
+	console.log(pagePath)
+
+	// Check if the current page path starts with any excluded path
+	var shouldHideLangSelector = excludedPaths.some(function(basePath) {
+		return pagePath.startsWith(basePath);
+	});
+
+	// Hide the language selector if the page falls under the excluded paths
+	if (shouldHideLangSelector) {
+		$('#langselect').hide();
+	} else {
+		$('#langselect').show(); // Ensure it's shown if not excluded
+	}
 });
 
 $(function(){
@@ -21,7 +42,7 @@ $(function(){
 		// Convert language codes
 		var siteLang = DOCUMENTATION_OPTIONS['LANGUAGE'];
 		var currentLang = convertLangCode(siteLang);
-		var newLang = convertLangCode($('#langselect').val());;
+		var newLang = convertLangCode($('#langselect').val());
 
 		pageURL = pageURL.replace(siteURL + currentLang, "");
 		var newFullURL = siteURL + newLang + pageURL;

--- a/_static/js/lang.js
+++ b/_static/js/lang.js
@@ -1,26 +1,6 @@
 $(document).ready(function() {
 	/* Select current language */
 	$('#langselect').val(DOCUMENTATION_OPTIONS['LANGUAGE']);
-	
-	/* Set alternate links 
-	var langs = [ "de", "en", "es", "fr", "pt", "vi", "el", "ru", "ko", "ja", "zh-Hans", "zh-Hant", "ar", "x-default" ];
-	var pageURL = $(location).attr("href");
-	pageURL = pageURL.replace("https://docs.dash.org/" + DOCUMENTATION_OPTIONS['LANGUAGE'] , "");
-	$.each(langs, function(index, value) {
-		var link = document.createElement('link');
-		link.rel = "alternate";
-		link.hreflang = value;
-		if (value == "x-default") {
-			link.href = "https://docs.dash.org/en" + pageURL;
-		} else if (value == "zh-Hans") {
-			link.href = "https://docs.dash.org/zh_CN" + pageURL;
-		} else if (value == "zh-Hant") {
-			link.href = "https://docs.dash.org/zh_TW" + pageURL;
-		} else {
-			link.href = "https://docs.dash.org/" + value + pageURL;
-		}
-		jQuery('head').append(link);
-	});*/
 });
 
 $(function(){


### PR DESCRIPTION
Only show the language selector on User Docs pages since they are the only ones that have other languages available.