### PR TITLE
chore: update myst-parser to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel==2.16.0
-myst-parser==2.0.0
+myst-parser==4.0.0
 pydata-sphinx-theme==0.14.4
 sphinx==7.2.6
 sphinxcontrib-googleanalytics==0.4


### PR DESCRIPTION
Update to v4.0.0

Preview: https://dash-docs--455.org.readthedocs.build/en/455/