### PR TITLE
build: bump to latest supported version of python

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
    os: "ubuntu-24.04"
    tools:
-      python: "3.10"
+      python: "3.13"
 
 python:
    install:


### PR DESCRIPTION
Update to use Python 3.13 for builds