### PR TITLE
docs: update insight testnet url

### DIFF
--- a/_templates/sidebar-main.html
+++ b/_templates/sidebar-main.html
@@ -140,7 +140,7 @@
               <li class="toctree-l2"><a class="reference external" href="https://insight.dash.org/insight/">Mainnet Block
                   Explorer</a></li>
               <li class="toctree-l2"><a class="reference external"
-                  href="https://insight.testnet.networks.dash.org:3002/insight/">Testnet Block
+                  href="https://insight.testnet.networks.dash.org">Testnet Block
                   Explorer</a></li>
               <li class="toctree-l2"><a class="reference external" href="http://faucet.testnet.networks.dash.org/">Testnet Faucet
                 </a></li>

--- a/docs/core/guide/dash-features-coinjoin.md
+++ b/docs/core/guide/dash-features-coinjoin.md
@@ -36,7 +36,7 @@ The CoinJoin denominations include a bit mapping to easily differentiate them. T
 
 Protocol version 70213 added a 5th denomination (0.001 DASH).
 
-[Example Testnet denomination creation transaction](https://insight.testnet.networks.dash.org:3002/insight/tx/f0174fc87d68a18617c2990df4d9455c0459c601d2d6473934357a66f9b8b70a)
+[Example Testnet denomination creation transaction](https://insight.testnet.networks.dash.org/insight/tx/f0174fc87d68a18617c2990df4d9455c0459c601d2d6473934357a66f9b8b70a)
 
 **Creating Collaterals**
 
@@ -44,9 +44,9 @@ Collaterals are used to pay CoinJoin fees, but are kept separate from the denomi
 
 In protocol versions > 70208, Dash Core can use any [input](../resources/glossary.md#input) from 1x the minimum collateral amount to the maximum collateral amount.
 
-[Example Testnet collateral creation transaction](https://insight.testnet.networks.dash.org:3002/insight/tx/8f9b15973983876f7ce4eb2c32b09690dfb0432d2caf6c6df516196a8d17689f)
+[Example Testnet collateral creation transaction](https://insight.testnet.networks.dash.org/insight/tx/8f9b15973983876f7ce4eb2c32b09690dfb0432d2caf6c6df516196a8d17689f)
 
-[Example Testnet collateral payment transaction](https://insight.testnet.networks.dash.org:3002/insight/tx/de51e6f7c5ef75aad0dbb0a808ef4873d7ef6d67b25f3a658d5a241db4f3eeeb)
+[Example Testnet collateral payment transaction](https://insight.testnet.networks.dash.org/insight/tx/de51e6f7c5ef75aad0dbb0a808ef4873d7ef6d67b25f3a658d5a241db4f3eeeb)
 
 ## CoinJoin Processing
 

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -148,7 +148,7 @@ dashcore/wallet-configuration-file
 
 resources/glossary
 Mainnet Block Explorer <https://insight.dash.org/insight/>
-Testnet Block Explorer <https://insight.testnet.networks.dash.org:3002/insight/>
+Testnet Block Explorer <https://insight.testnet.networks.dash.org>
 Testnet Faucet <http://faucet.testnet.networks.dash.org/>
 API Services <https://www.dash.org/providers-and-tools/#custody-and-api>
 SDK Resources <https://docs.dash.org/en/stable/docs/user/developers/integration-sdks.html>

--- a/docs/user/developers/testnet.rst
+++ b/docs/user/developers/testnet.rst
@@ -64,8 +64,7 @@ Faucets
 Explorers
 ---------
 
-- https://insight.testnet.networks.dash.org:3002/insight
-- http://insight.testnet.networks.dash.org:3001/insight
+- https://insight.testnet.networks.dash.org/insight
 
 Masternodes
 ===========

--- a/docs/user/masternodes/setup-testnet.rst
+++ b/docs/user/masternodes/setup-testnet.rst
@@ -187,7 +187,7 @@ Now send exactly 1000 DASH in a single transaction to the new address
 you generated in the previous step. This may be sent from another
 wallet, or from funds already held in your current wallet. Once the
 transaction is complete, view the transaction in a `blockchain explorer
-<https://testnet-insight.dash.org/insight/>`_ by searching for the
+<https://insight.testnet.networks.dash.org/insight/>`_ by searching for the
 address. You will need 15 confirmations before you can register the
 masternode, but you can continue with the next step at this point
 already: generating your masternode operator key.


### PR DESCRIPTION
Testnet insight is now located at https://insight.testnet.networks.dash.org/insight/.

<!-- Replace -->
Preview build: https://dash-docs--466.org.readthedocs.build/en/466/
<!-- Replace -->
