### PR TITLE
ci: update workflow cron time

### DIFF
--- a/.github/workflows/core-download-update.yml
+++ b/.github/workflows/core-download-update.yml
@@ -4,8 +4,8 @@ on:
   repository_dispatch:
     types: [release_published]
   workflow_dispatch:  # This allows the workflow to be triggered manually
-  schedule: # Run daily at midnight UTC
-    - cron: 0 0 * * *
+  schedule: # Run daily at midnight and noon UTC
+    - cron: 0 0,12 * * *
 
 jobs:
   update-core-download-links:

--- a/.github/workflows/dashmate-update.yml
+++ b/.github/workflows/dashmate-update.yml
@@ -4,8 +4,8 @@ on:
   repository_dispatch:
     types: [release_published]
   workflow_dispatch:  # This allows the workflow to be triggered manually
-  schedule: # Run daily at midnight UTC
-    - cron: 0 0 * * *  
+  schedule: # Run daily at midnight and noon UTC
+    - cron: 0 0,12 * * *  
 
 jobs:
   update-dashmate-version:

--- a/.github/workflows/evo-tool-download-update.yml
+++ b/.github/workflows/evo-tool-download-update.yml
@@ -4,8 +4,8 @@ on:
   repository_dispatch:
     types: [release_published]
   workflow_dispatch:  # This allows the workflow to be triggered manually
-  schedule: # Run daily at midnight UTC
-    - cron: 0 0 * * *
+  schedule: # Run daily at midnight and noon UTC
+    - cron: 0 0,12 * * *
 
 jobs:
   update-evo-tool-download-links:


### PR DESCRIPTION
Run every 12 hours to catch releases more quickly