### PR TITLE
ci: don't create pull request if version is null

### DIFF
--- a/scripts/core-download-link-update.sh
+++ b/scripts/core-download-link-update.sh
@@ -9,10 +9,10 @@ NEW_VERSION=$(curl -s \
   https://api.github.com/repos/dashpay/dash/releases/latest | \
   jq -r '.tag_name' | sed 's/^v//')
 
-if [[ $? -ne 0 || -z "$NEW_VERSION" ]]; then
-  echo "Error: Unexpected response when retrieving the current Dash Core version. Received: $NEW_VERSION"
-else
-  # Print the extracted values (for verification)
+# Check if curl or jq failed, or if NEW_VERSION is null or empty
+if [[ $? -ne 0 || -z "$NEW_VERSION" || "$NEW_VERSION" == "null" ]]; then
+  echo "Error: Unexpected response when retrieving the current Dash Core version. Ignoring update."
+else  # Print the extracted values (for verification)
   echo "Extracted Version: $NEW_VERSION"
   # git checkout -b v$NEW_VERSION-links # Uncomment to use locally
 

--- a/scripts/evo-tool-download-link-update.sh
+++ b/scripts/evo-tool-download-link-update.sh
@@ -9,7 +9,7 @@ NEW_VERSION=$(curl -s \
   https://api.github.com/repos/dashpay/dash-evo-tool/releases/latest | \
   jq -r '.tag_name' | sed 's/^v//')
 
-if [[ $? -ne 0 || -z "$NEW_VERSION" ]]; then
+if [[ $? -ne 0 || -z "$NEW_VERSION" || "$NEW_VERSION" == "null" ]]; then
   echo "Error: Unexpected response when retrieving the current version. Received: $NEW_VERSION"
 else
   # Print the extracted values (for verification)


### PR DESCRIPTION
Previously a PR might be created if a value was received but it was "null". Skip those cases now.