### PR TITLE
docs(p2p): qrinfo correction

### DIFF
--- a/docs/core/reference/p2p-network-data-messages.md
+++ b/docs/core/reference/p2p-network-data-messages.md
@@ -886,7 +886,7 @@ Note: In the following fields, `c` refers to the quorum cycle length. This is sy
 | 1 | extraShare | bool | Required | Flag to indicate if an extra share is requested |
 | Varies | quorumSnapshot<br>AtHMinus4C | CQuorumSnapshot | Optional | Returned only if `extraShare` is on. See below for sub-message contents. |
 | Varies | mnListDiff<br>AtHMinus4C | CSimplifiedMNListDiff | Optional | Returned only if `extraShare` is on. As in DIP-4.
-| 1-9 | lastQuorumHashPer<br>IndexSize | compactSize uint | Required | Number of elements in `lastCommitmentPerIndex`
+| 1-9 | lastCommitment<br>PerIndexSize | compactSize uint | Required | Number of elements in `lastCommitmentPerIndex`
 | Varies  | lastCommitment<br>PerIndex | CFinalCommitment[]<br>(see [qfcommit](./p2p-network-quorum-messages.md#qfcommit)) |  Required | Contains the most recent quorum commitment for each quorumIndex. Ordered by quorumIndex.
 | 1-9 | quorumSnapshot<br>ListSize | compactSize uint | Required | Number of elements in `quorumSnapshotList`
 | Varies | quorumSnapshot<br>List | CQuorumSnapshot[] | Required | The snapshots required to reconstruct the quorums built at `h` in heightsLists. Ordered from oldest to newest

--- a/docs/core/reference/p2p-network-data-messages.md
+++ b/docs/core/reference/p2p-network-data-messages.md
@@ -887,7 +887,7 @@ Note: In the following fields, `c` refers to the quorum cycle length. This is sy
 | Varies | quorumSnapshot<br>AtHMinus4C | CQuorumSnapshot | Optional | Returned only if `extraShare` is on. See below for sub-message contents. |
 | Varies | mnListDiff<br>AtHMinus4C | CSimplifiedMNListDiff | Optional | Returned only if `extraShare` is on. As in DIP-4.
 | 1-9 | lastQuorumHashPer<br>IndexSize | compactSize uint | Required | Number of elements in `lastCommitmentPerIndex`
-| 32 * `lastQuorum`<br>`HashPer`<br>`IndexSize`  | lastCommitment<br>PerIndex | uint256_t[] |  Required | Contains the most recent commitment for each quorumIndex. Ordered by quorumIndex.
+| Varies  | lastCommitment<br>PerIndex | CFinalCommitment[]<br>(see [qfcommit](./p2p-network-quorum-messages.md#qfcommit)) |  Required | Contains the most recent quorum commitment for each quorumIndex. Ordered by quorumIndex.
 | 1-9 | quorumSnapshot<br>ListSize | compactSize uint | Required | Number of elements in `quorumSnapshotList`
 | Varies | quorumSnapshot<br>List | CQuorumSnapshot[] | Required | The snapshots required to reconstruct the quorums built at `h` in heightsLists. Ordered from oldest to newest
 | 1-9 | mnListDiff<br>ListSize | compactSize uint | Required | Number of elements in `mnListDiffList`


### PR DESCRIPTION
Align qrinfo in docs with [DIP-24 info](https://github.com/dashpay/dips/blob/master/dip-0024.md#simplified-verification-of-llmqs). Issue reported by @QuantumExplorer 

<!-- Replace -->
Preview build: https://dash-docs--489.org.readthedocs.build/en/489/docs/core/reference/p2p-network-data-messages.html#qrinfo
<!-- Replace -->
