### PR TITLE
docs(core): fixed file name for a certificate bundle

### DIFF
--- a/docs/user/masternodes/setup-evonode.rst
+++ b/docs/user/masternodes/setup-evonode.rst
@@ -632,7 +632,7 @@ There are two ways to get SSL certificates:
    intermediate/root certificates if present. If a bundle file is present, you need to concatenate it
    with the certificate file::
    
-    cat certificate.crt bundle.crt > full_chain.crt
+    cat certificate.crt bundle.crt > bundle.crt
 
    Verify the validity of the private key and certificate chain by running these commands::
 


### PR DESCRIPTION
# Issue

In the [discord](https://discord.com/channels/484546513507188745/496953691203698703/1345262807733501983), a one MNO noticed that certificate bundle name `full_chain.crt`is not correct for dashmate, as dashmate is using `bundle.crt`

<!-- Replace -->
Preview build: https://dash-docs--495.org.readthedocs.build/en/495/
<!-- Replace -->
