### PR TITLE
docs: fix old transifex links

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ designed to be built with [Sphinx](https://www.sphinx-doc.org/) and hosted by [R
 Docs](https://readthedocs.org/). Feel free to [open an
 issue](https://github.com/dashpay/docs/issues/new/choose) or submit PRs modifying the English source
 text in this repository. Contributions to translations of the source text are welcomed on
-[Transifex](https://www.transifex.com/dash/dash-docs/).
+[Transifex](https://app.transifex.com/dash/dash-docs/).
 
 ### Package management
 

--- a/docs/user/developers/translating.rst
+++ b/docs/user/developers/translating.rst
@@ -18,10 +18,10 @@ joins the team, they are able to choose the languages they feel able to
 translate. They can then work on any projects specifying this language
 as a target language.
 
-- `Transifex <https://www.transifex.com>`_
+- `Transifex <https://app.transifex.com>`_
 - `Transifex Documentation <https://docs.transifex.com>`_
-- `Dash translation projects <https://www.transifex.com/dash/>`_
-- `Dash translators team <https://www.transifex.com/dash/teams/>`_
+- `Dash translation projects <https://app.transifex.com/dash/>`_
+- `Dash translators team <https://app.transifex.com/dash/teams/>`_
 
 In general, languages with minimal regional variation are to be
 translated into the common language (rather than regional) target.
@@ -56,7 +56,7 @@ product is written.
 Dash Core
 =========
 
-https://www.transifex.com/dash/dash/
+https://app.transifex.com/dash/dash/
 
 This project contains a file named ``dash_en.ts``, which is an export of
 all translatable user-facing content in the :ref:`Dash Core Wallet
@@ -96,7 +96,7 @@ Punctuation
 Dash Docs
 =========
 
-https://www.transifex.com/dash/dash-docs/
+https://app.transifex.com/dash/dash-docs/
 
 This project contains all content from the Dash Documentation hosted at
 https://docs.dash.org (probably the site you are reading now). Each
@@ -158,7 +158,7 @@ External hyperlinks
 Dash Graphics
 =============
 
-https://www.transifex.com/dash/dash-graphics/
+https://app.transifex.com/dash/dash-graphics/
 
 Dash visual products such as infographics, flyers and conference
 handouts are produced using Adobe InDesign, Adobe Illustrator or
@@ -179,7 +179,7 @@ in the visual design.
 Dash iOS Wallet
 ===============
 
-https://www.transifex.com/dash/dash-mobile-wallets/
+https://app.transifex.com/dash/dash-mobile-wallets/
 
 All language content from the :ref:`Dash iOS Wallet <dash-ios-wallet>`
 are available for translation in this project. Please have a device
@@ -191,7 +191,7 @@ to the instructions above for Dash Core Wallet.
 Dash Android Wallet
 ===================
 
-https://www.transifex.com/dash/dash-mobile-wallets/
+https://app.transifex.com/dash/dash-mobile-wallets/
 
 All language content from the 
 :ref:`Dash Android Wallet <dash-android-wallet>` are available for
@@ -204,7 +204,7 @@ instructions above for Dash Core Wallet.
 Dash Videos
 ===========
 
-https://www.transifex.com/dash/dash-videos/
+https://app.transifex.com/dash/dash-videos/
 
 This section primarily contains language content from Amanda B.
 Johnson's popular `Dash School <https://www.youtube.com/watch?v=e7UwwcCK
@@ -218,7 +218,7 @@ YouTube.
 Dash Website
 ============
 
-https://www.transifex.com/dash/dash-website/
+https://app.transifex.com/dash/dash-website/
 
 The Dash website at https://www.dash.org is available for translation in
 Transifex. Please have the website open while you translate to correctly

--- a/docs/user/marketing.rst
+++ b/docs/user/marketing.rst
@@ -45,7 +45,7 @@ conferences and events. Prepared by community member Essra in 2018
 following proposal sponsorship for the German Dash Embassy D-A-CH.
 
 This design can be translated into your language at `Transifex here
-<https://www.transifex.com/dash/dash-graphics/dash-brochurexlsx/>`__.
+<https://app.transifex.com/dash/dash-graphics/dash-brochurexlsx/>`__.
 For more information on translating Dash products on Transifex, see
 :ref:`here <translating-dash>`. Please contact leon.white@dash.org once
 translation is complete to request layout of the completed translation.
@@ -78,7 +78,7 @@ Essra in 2018 following proposal sponsorship for the German Dash
 Embassy D-A-CH.
 
 This design can be translated into your language at `Transifex here
-<https://www.transifex.com/dash/dash-graphics/dash-flyerxlsx/>`__.
+<https://app.transifex.com/dash/dash-graphics/dash-flyerxlsx/>`__.
 For more information on translating Dash products on Transifex, see
 :ref:`here <translating-dash>`. Please contact leon.white@dash.org once
 translation is complete to request layout of the completed translation.
@@ -116,7 +116,7 @@ conferences. The current version is **v3.1**; previous versions are
 available below.
 
 This design can be translated into your language at `Transifex here
-<https://www.transifex.com/dash/dash-graphics/dash-handout-v30txt/>`__.
+<https://app.transifex.com/dash/dash-graphics/dash-handout-v30txt/>`__.
 For more information on translating Dash products on Transifex, see
 :ref:`here <translating-dash>`. Please contact leon.white@dash.org once
 translation is complete to request layout of the completed translation.
@@ -176,7 +176,7 @@ delivered by building on the Bitcoin code base. Based on an original
 design by community member J. Arroyo.
 
 This design can be translated into your language at `Transifex here
-<https://www.transifex.com/dash/dash-graphics/the-dash-
+<https://app.transifex.com/dash/dash-graphics/the-dash-
 differencexlsx/>`__. For more information on translating Dash products
 on Transifex, see :ref:`here <translating-dash>`. Please contact
 leon.white@dash.org once translation is complete to request layout of
@@ -238,7 +238,7 @@ This infographic refutes many common yet uninformed arguments made
 against Dash. Based on an original design by community member DashDude.
 
 This design can be translated into your language at `Transifex here
-<https://www.transifex.com/dash/dash-graphics/misconceptionsxlsx/>`__.
+<https://app.transifex.com/dash/dash-graphics/misconceptionsxlsx/>`__.
 For more information on translating Dash products on Transifex, see
 :ref:`here <translating-dash>`. Please contact leon.white@dash.org once
 translation is complete to request layout of the completed translation.

--- a/transifex/README.md
+++ b/transifex/README.md
@@ -40,7 +40,7 @@ example:
 [https://www.transifex.com]
 api_hostname = https://api.transifex.com
 hostname = https://www.transifex.com
-password = <enter password generated on https://www.transifex.com/user/settings/api/ here>
+password = <enter password generated on https://app.transifex.com/user/settings/api/ here>
 username = api
 ```
 


### PR DESCRIPTION
Transifex changed the url format at some point. This PR updates our links to the new format. Closes #508.

Preview build: https://dash-docs--510.org.readthedocs.build/en/510/