### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/user/introduction/about.rst
+++ b/docs/user/introduction/about.rst
@@ -100,7 +100,7 @@ described in Bitcoin Improvement Proposals (BIPs).
 - `PDF whitepaper <https://github.com/dashpay/docs/raw/master/binary/Dash%20Whitepaper%20-%20V2.pdf>`_
 - `Dash Improvement Proposals (DIPs) <https://github.com/dashpay/dips>`_
 - `Bitcoin Improvement Proposals (BIPs) <https://github.com/bitcoin/bips>`_
-- `Evolution Initial Design Document <https://www.dash.org/wp-content/uploads/Dash-Evolution-Initial-Design-Document.pdf>`_
+- `Evolution Initial Design Document <https://media.dash.org/wp-content/uploads/Dash-Evolution-Initial-Design-Document.pdf>`_
 - `Original Darkcoin whitepaper (PDF) <https://github.com/dashpay/docs/raw/master/binary/Dash%20Whitepaper%20-%20Darkcoin.pdf>`_
 - `InstantSend whitepaper (PDF) <https://github.com/dashpay/docs/raw/master/binary/Dash%20Whitepaper%20-%20Transaction%20Locking%20and%20Masternode%20Consensus.pdf>`_
 


### PR DESCRIPTION
Closes #515

<!-- Replace -->
Preview build: https://dash-docs--516.org.readthedocs.build/en/516/
<!-- Replace -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the link to the "Evolution Initial Design Document" in the whitepaper section to ensure it directs to the correct URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->