### PR TITLE
chore: update discord link

### DIFF
--- a/docs/user/developers/testnet.rst
+++ b/docs/user/developers/testnet.rst
@@ -44,7 +44,7 @@ Tools and links
 
 The links below were collected from various community sources and may
 not necessarily be online or functioning at any given time. Please join
-`Dash Discord <http://staydashy.com/>`_ or the `Dash Forum
+`Dash Discord <http://chat.dash.org/>`_ or the `Dash Forum
 <https://www.dash.org/forum/>`_ if you have a question relating to a
 specific service.
 

--- a/docs/user/governance/eight-steps.rst
+++ b/docs/user/governance/eight-steps.rst
@@ -28,7 +28,7 @@ Run a pre-proposal discussion
   out if someone has proposed something similar in the past, and whether
   it succeeded or failed. There are `pre-proposal channels on the forum
   <https://www.dash.org/forum/topic/pre-budget-proposal-
-  discussions.93/>`__ and `Dash Discord <http://staydashy.com>`__,
+  discussions.93/>`__ and `Dash Discord <http://chat.dash.org/>`__,
   and `Reddit <https://www.reddit.com/r/dashpay>`__ also attracts a lot
   of views - consider the discussion on these channels to be the
   research phase of your proposal. Later, you can post a link to the


### PR DESCRIPTION
Replace older Discord link with current one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Dash Discord links across developer and governance docs to the current chat.dash.org domain to ensure users are directed to the official community channel. Existing forum link unchanged. Text-only updates; no functional changes.


<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Replace -->
Preview build: https://dash-docs--539.org.readthedocs.build/en/539/
<!-- Replace -->
