### PR TITLE
feat: add canonical URL meta tag to improve SEO

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,5 +1,9 @@
 {% extends "!layout.html" %}
 {% block extrahead %}
+    {# Canonical URL: stops Google choosing /en/latest/ as canonical #}
+    {% if canonical_url %}
+    <link rel="canonical" href="{{ canonical_url }}" />
+    {% endif %}
     <link href="{{ pathto("_static/style.css", True) }}" rel="stylesheet" type="text/css">
     <meta name="google-site-verification" content="JVzTMPjsCY-U-SaJERGf-eviRxXUPfFkPFdiF_MINCU" />
     <meta name="author" content="Dash Core Group, Inc." />


### PR DESCRIPTION
Prevents Google from choosing /en/latest/ as canonical URL, helping to resolve duplicate content issues across versions.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional canonical URL support to help manage SEO and prevent issues with duplicate content across multiple URLs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->