### PR TITLE
docs: remove pool of stake from hosting list

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -78,18 +78,22 @@ gettext_compact = False
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
 exclude_patterns = [
+    '.devcontainer',
+    '.DS_Store',
     '_build',
     'Thumbs.db',
-    '.DS_Store',
+    # Directories to exclude
+    'local/*',
+    'scripts/*',
+    'transifex/*',
+    'venv/*',
+    'dash-core-src',
+    # Docs related files to exclude
+    'CLAUDE.md',
     'README.md',
-    '.devcontainer',
-    'transifex',
     'docs/core/api/ai-prompt.md',
     'docs/img/dev/gifs/README.md',    
     'docs/user/wallets/electrum/dip3_p2sh_howto.md',
-    'scripts/*',
-    'venv',
-    'dash-core-src'
 ]
 
 # The name of the Pygments (syntax highlighting) style to use.

--- a/docs/user/masternodes/hosting.rst
+++ b/docs/user/masternodes/hosting.rst
@@ -78,25 +78,6 @@ https://dashmasternode.io
 - `Email <sidhosting@protonmail.com>`__
 
 
-Pool of Stake
--------------
-
-.. image:: img/pool-of-stake.svg
-   :width: 200px
-   :align: right
-   :target: https://www.poolofstake.io
-
-https://www.poolofstake.io
-
-- Operated by: Pool of Stake OÜ
-- Services: Hosting, Shares
-- 15% of masternode payments (5% with tokens)
-- `Site <https://www.poolofstake.io>`__
-- `Email <mail@poolofstake.io>`__
-- `Twitter <https://twitter.com/poolofstake>`__
-- `Telegram <https://telegram.me/poolofstake>`__
-
-
 NodeHub.io
 ----------
 


### PR DESCRIPTION
No longer provides Dash services.

Also updated/re-organized exclude patterns

<!-- Replace -->
Preview build: https://dash-docs--557.org.readthedocs.build/en/557/
<!-- Replace -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Pool of Stake hosting provider from the master nodes hosting services list.

* **Chores**
  * Updated documentation configuration to refine build process management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->