### PR TITLE
docs: update dash evo tool installation

### DIFF
--- a/docs/user/network/dash-evo-tool/index.rst
+++ b/docs/user/network/dash-evo-tool/index.rst
@@ -27,7 +27,7 @@ Linux, MacOS, or Windows packages are available on the `GitHub releases page
 Operating System, then unzip the downloaded file:
 
 * `Mac (Apple Silicon / arm64) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.9.3/dash-evo-tool-arm64-mac.zip>`_
-* `Mac (Intel / x86) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.9.3/dash-evo-tool-x86_64-mac.zip>`_
+* `Mac (Intel / x86_64) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.9.3/dash-evo-tool-x86_64-mac.zip>`_
 * `Linux (x86_64) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.9.3/dash-evo-tool-x86_64-linux.zip>`_
 * `Linux (arm64) <https://github.com/dashpay/dash-evo-tool/releases/download/v0.9.3/dash-evo-tool-arm64-linux.zip>`_ 
 * `Windows <https://github.com/dashpay/dash-evo-tool/releases/download/v0.9.3/dash-evo-tool-windows.zip>`_


### PR DESCRIPTION
Include Windows dependency requirements

<!-- Replace -->
Preview build: https://dash-docs--561.org.readthedocs.build/en/561/
<!-- Replace -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added platform-specific prebuilt binary download links for Mac (Apple Silicon arm64, Intel x86_64), Linux (x86_64, arm64), and Windows.
  * Removed older, generic/truncated prebuilt binary entries.
  * Added a Windows prerequisites tip (Microsoft Visual C++ Redistributable and OpenGL 2.0 compatibility) and positioned it before the configuration section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->