### PR TITLE
fix: correct double-slash paths in .tx/config file_filter entries

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -42,7 +42,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--developers--integration-apis]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/developers/integration-apis.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/developers/integration-apis.po
 source_file            = locale/pot/docs/user/developers/integration-apis.pot
 type                   = PO
 minimum_perc           = 0
@@ -51,7 +51,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--developers--integration-sdks]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/developers/integration-sdks.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/developers/integration-sdks.po
 source_file            = locale/pot/docs/user/developers/integration-sdks.pot
 type                   = PO
 minimum_perc           = 0
@@ -60,7 +60,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--developers--sporks]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/developers/sporks.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/developers/sporks.po
 source_file            = locale/pot/docs/user/developers/sporks.pot
 type                   = PO
 minimum_perc           = 0
@@ -99,7 +99,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--governance--eight-steps]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/governance/eight-steps.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/governance/eight-steps.po
 source_file            = locale/pot/docs/user/governance/eight-steps.pot
 source_lang            = en
 type                   = PO
@@ -109,7 +109,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--governance--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/governance/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/governance/index.po
 source_file            = locale/pot/docs/user/governance/index.pot
 source_lang            = en
 type                   = PO
@@ -119,7 +119,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--governance--understanding]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/governance/understanding.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/governance/understanding.po
 source_file            = locale/pot/docs/user/governance/understanding.pot
 source_lang            = en
 type                   = PO
@@ -129,7 +129,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--governance--using]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/governance/using.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/governance/using.po
 source_file            = locale/pot/docs/user/governance/using.pot
 source_lang            = en
 type                   = PO
@@ -139,7 +139,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/index.po
 source_file            = locale/pot/docs/user/index.pot
 source_lang            = en
 type                   = PO
@@ -149,7 +149,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--introduction--about]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/introduction/about.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/introduction/about.po
 source_file            = locale/pot/docs/user/introduction/about.pot
 source_lang            = en
 type                   = PO
@@ -159,7 +159,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--introduction--features]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/introduction/features.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/introduction/features.po
 source_file            = locale/pot/docs/user/introduction/features.pot
 source_lang            = en
 type                   = PO
@@ -169,7 +169,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--introduction--how-to-buy]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/introduction/how-to-buy.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/introduction/how-to-buy.po
 source_file            = locale/pot/docs/user/introduction/how-to-buy.pot
 source_lang            = en
 type                   = PO
@@ -179,7 +179,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--introduction--information]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/introduction/information.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/introduction/information.po
 source_file            = locale/pot/docs/user/introduction/information.pot
 source_lang            = en
 type                   = PO
@@ -189,7 +189,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--introduction--safety]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/introduction/safety.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/introduction/safety.po
 source_file            = locale/pot/docs/user/introduction/safety.pot
 source_lang            = en
 type                   = PO
@@ -199,7 +199,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--legal]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/legal.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/legal.po
 source_file            = locale/pot/docs/user/legal.pot
 source_lang            = en
 type                   = PO
@@ -209,7 +209,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--marketing]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/marketing.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/marketing.po
 source_file            = locale/pot/docs/user/marketing.pot
 source_lang            = en
 type                   = PO
@@ -219,7 +219,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--dashmate-existing-host]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/dashmate-existing-host.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/dashmate-existing-host.po
 source_file            = locale/pot/docs/user/masternodes/dashmate-existing-host.pot
 type                   = PO
 minimum_perc           = 0
@@ -228,7 +228,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--dashmate-new-host]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/dashmate-new-host.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/dashmate-new-host.po
 source_file            = locale/pot/docs/user/masternodes/dashmate-new-host.pot
 type                   = PO
 minimum_perc           = 0
@@ -237,7 +237,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--dashmate-upgrade-v1]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/dashmate-upgrade-v1.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/dashmate-upgrade-v1.po
 source_file            = locale/pot/docs/user/masternodes/dashmate-upgrade-v1.pot
 type                   = PO
 minimum_perc           = 0
@@ -246,7 +246,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--hosting]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/hosting.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/hosting.po
 source_file            = locale/pot/docs/user/masternodes/hosting.pot
 source_lang            = en
 type                   = PO
@@ -256,7 +256,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/index.po
 source_file            = locale/pot/docs/user/masternodes/index.pot
 source_lang            = en
 type                   = PO
@@ -266,7 +266,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--maintenance]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/maintenance.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/maintenance.po
 source_file            = locale/pot/docs/user/masternodes/maintenance.pot
 source_lang            = en
 type                   = PO
@@ -276,7 +276,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--server-config]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/server-config.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/server-config.po
 source_file            = locale/pot/docs/user/masternodes/server-config.pot
 type                   = PO
 minimum_perc           = 0
@@ -285,7 +285,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--setup]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/setup.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/setup.po
 source_file            = locale/pot/docs/user/masternodes/setup.pot
 source_lang            = en
 type                   = PO
@@ -295,7 +295,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--setup-evonode]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/setup-evonode.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/setup-evonode.po
 source_file            = locale/pot/docs/user/masternodes/setup-evonode.pot
 type                   = PO
 minimum_perc           = 0
@@ -304,7 +304,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--setup-testnet]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/setup-testnet.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/setup-testnet.po
 source_file            = locale/pot/docs/user/masternodes/setup-testnet.pot
 source_lang            = en
 type                   = PO
@@ -314,7 +314,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--masternodes--understanding]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/masternodes/understanding.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/masternodes/understanding.po
 source_file            = locale/pot/docs/user/masternodes/understanding.pot
 source_lang            = en
 type                   = PO
@@ -324,7 +324,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--mining--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/mining/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/mining/index.po
 source_file            = locale/pot/docs/user/mining/index.pot
 source_lang            = en
 type                   = PO
@@ -334,7 +334,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--mining--p2pool]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/mining/p2pool.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/mining/p2pool.po
 source_file            = locale/pot/docs/user/mining/p2pool.pot
 source_lang            = en
 type                   = PO
@@ -344,7 +344,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--mining--pools]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/mining/pools.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/mining/pools.po
 source_file            = locale/pot/docs/user/mining/pools.pot
 source_lang            = en
 type                   = PO
@@ -354,7 +354,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--network--dash-evo-tool--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/network/dash-evo-tool/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/network/dash-evo-tool/index.po
 source_file            = locale/pot/docs/user/network/dash-evo-tool/index.pot
 type                   = PO
 minimum_perc           = 0
@@ -363,7 +363,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--network--dashmate--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/network/dashmate/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/network/dashmate/index.po
 source_file            = locale/pot/docs/user/network/dashmate/index.pot
 type                   = PO
 minimum_perc           = 0
@@ -372,7 +372,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--network--electrumx-server]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/network/electrumx-server.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/network/electrumx-server.po
 source_file            = locale/pot/docs/user/network/electrumx-server.pot
 source_lang            = en
 type                   = PO
@@ -382,7 +382,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--android--advanced-functions]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/android/advanced-functions.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/advanced-functions.po
 source_file            = locale/pot/docs/user/wallets/android/advanced-functions.pot
 source_lang            = en
 type                   = PO
@@ -392,7 +392,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--android--getting-started]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/android/getting-started.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/getting-started.po
 source_file            = locale/pot/docs/user/wallets/android/getting-started.pot
 source_lang            = en
 type                   = PO
@@ -402,7 +402,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--android--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/android/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/index.po
 source_file            = locale/pot/docs/user/wallets/android/index.pot
 source_lang            = en
 type                   = PO
@@ -412,7 +412,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--android--installation]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/android/installation.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/android/installation.po
 source_file            = locale/pot/docs/user/wallets/android/installation.pot
 source_lang            = en
 type                   = PO
@@ -422,7 +422,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--advanced]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/advanced.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/advanced.po
 source_file            = locale/pot/docs/user/wallets/dashcore/advanced.pot
 source_lang            = en
 type                   = PO
@@ -432,7 +432,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--backup]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/backup.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/backup.po
 source_file            = locale/pot/docs/user/wallets/dashcore/backup.pot
 source_lang            = en
 type                   = PO
@@ -442,7 +442,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--cmd-rpc]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/cmd-rpc.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/cmd-rpc.po
 source_file            = locale/pot/docs/user/wallets/dashcore/cmd-rpc.pot
 source_lang            = en
 type                   = PO
@@ -452,7 +452,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--coinjoin-instantsend]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/coinjoin-instantsend.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/coinjoin-instantsend.po
 source_file            = locale/pot/docs/user/wallets/dashcore/coinjoin-instantsend.pot
 source_lang            = en
 type                   = PO
@@ -462,7 +462,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/index.po
 source_file            = locale/pot/docs/user/wallets/dashcore/index.pot
 source_lang            = en
 type                   = PO
@@ -472,7 +472,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation.po
 source_file            = locale/pot/docs/user/wallets/dashcore/installation.pot
 source_lang            = en
 type                   = PO
@@ -482,7 +482,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation-linux]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-linux.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-linux.po
 source_file            = locale/pot/docs/user/wallets/dashcore/installation-linux.pot
 source_lang            = en
 type                   = PO
@@ -492,7 +492,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation-macos]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-macos.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-macos.po
 source_file            = locale/pot/docs/user/wallets/dashcore/installation-macos.pot
 source_lang            = en
 type                   = PO
@@ -502,7 +502,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--installation-windows]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-windows.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/installation-windows.po
 source_file            = locale/pot/docs/user/wallets/dashcore/installation-windows.pot
 source_lang            = en
 type                   = PO
@@ -512,7 +512,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--interface]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/interface.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/interface.po
 source_file            = locale/pot/docs/user/wallets/dashcore/interface.pot
 source_lang            = en
 type                   = PO
@@ -522,7 +522,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--dashcore--send-receive]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/dashcore/send-receive.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/dashcore/send-receive.po
 source_file            = locale/pot/docs/user/wallets/dashcore/send-receive.pot
 source_lang            = en
 type                   = PO
@@ -532,7 +532,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--advanced]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/advanced.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/advanced.po
 source_file            = locale/pot/docs/user/wallets/electrum/advanced.pot
 source_lang            = en
 type                   = PO
@@ -542,7 +542,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--faq]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/faq.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/faq.po
 source_file            = locale/pot/docs/user/wallets/electrum/faq.pot
 source_lang            = en
 type                   = PO
@@ -552,7 +552,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/index.po
 source_file            = locale/pot/docs/user/wallets/electrum/index.pot
 source_lang            = en
 type                   = PO
@@ -562,7 +562,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--installation]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/installation.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/installation.po
 source_file            = locale/pot/docs/user/wallets/electrum/installation.pot
 source_lang            = en
 type                   = PO
@@ -572,7 +572,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--security]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/security.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/security.po
 source_file            = locale/pot/docs/user/wallets/electrum/security.pot
 source_lang            = en
 type                   = PO
@@ -582,7 +582,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--electrum--send-receive]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/electrum/send-receive.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/electrum/send-receive.po
 source_file            = locale/pot/docs/user/wallets/electrum/send-receive.pot
 source_lang            = en
 type                   = PO
@@ -592,7 +592,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--hardware]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/hardware.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/hardware.po
 source_file            = locale/pot/docs/user/wallets/hardware.pot
 source_lang            = en
 type                   = PO
@@ -602,7 +602,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/index.po
 source_file            = locale/pot/docs/user/wallets/index.pot
 source_lang            = en
 type                   = PO
@@ -612,7 +612,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index-hardware]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/index-hardware.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-hardware.po
 source_file            = locale/pot/docs/user/wallets/index-hardware.pot
 source_lang            = en
 type                   = PO
@@ -622,7 +622,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index-paper]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/index-paper.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-paper.po
 source_file            = locale/pot/docs/user/wallets/index-paper.pot
 source_lang            = en
 type                   = PO
@@ -632,7 +632,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index-third-party]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/index-third-party.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-third-party.po
 source_file            = locale/pot/docs/user/wallets/index-third-party.pot
 source_lang            = en
 type                   = PO
@@ -642,7 +642,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--index-web]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/index-web.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/index-web.po
 source_file            = locale/pot/docs/user/wallets/index-web.pot
 source_lang            = en
 type                   = PO
@@ -652,7 +652,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--ios--advanced-functions]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/ios/advanced-functions.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/advanced-functions.po
 source_file            = locale/pot/docs/user/wallets/ios/advanced-functions.pot
 source_lang            = en
 type                   = PO
@@ -662,7 +662,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--ios--getting-started]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/ios/getting-started.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/getting-started.po
 source_file            = locale/pot/docs/user/wallets/ios/getting-started.pot
 source_lang            = en
 type                   = PO
@@ -672,7 +672,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--ios--index]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/ios/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/index.po
 source_file            = locale/pot/docs/user/wallets/ios/index.pot
 source_lang            = en
 type                   = PO
@@ -682,7 +682,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--ios--installation]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/ios/installation.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/ios/installation.po
 source_file            = locale/pot/docs/user/wallets/ios/installation.pot
 source_lang            = en
 type                   = PO
@@ -692,7 +692,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--paper]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/paper.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/paper.po
 source_file            = locale/pot/docs/user/wallets/paper.pot
 source_lang            = en
 type                   = PO
@@ -702,7 +702,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--recovery]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/recovery.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/recovery.po
 source_file            = locale/pot/docs/user/wallets/recovery.pot
 source_lang            = en
 type                   = PO
@@ -712,7 +712,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--signing]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/signing.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/signing.po
 source_file            = locale/pot/docs/user/wallets/signing.pot
 source_lang            = en
 type                   = PO
@@ -722,7 +722,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--third-party]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/third-party.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/third-party.po
 source_file            = locale/pot/docs/user/wallets/third-party.pot
 source_lang            = en
 type                   = PO
@@ -732,7 +732,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:docs--user--wallets--web]
-file_filter            = locale//<lang>/LC_MESSAGES/docs/user/wallets/web.po
+file_filter            = locale/<lang>/LC_MESSAGES/docs/user/wallets/web.po
 source_file            = locale/pot/docs/user/wallets/web.pot
 source_lang            = en
 type                   = PO
@@ -742,7 +742,7 @@ replace_edited_strings = false
 keep_translations      = true
 
 [o:dash:p:dash-docs:r:index]
-file_filter            = locale//<lang>/LC_MESSAGES/index.po
+file_filter            = locale/<lang>/LC_MESSAGES/index.po
 source_file            = locale/pot/index.pot
 source_lang            = en
 type                   = PO


### PR DESCRIPTION
## Summary

Fixes #541

All 69 `file_filter` entries in `.tx/config` contained double slashes in their paths:

```
locale//<lang>/LC_MESSAGES/...
```

This should be:

```
locale/<lang>/LC_MESSAGES/...
```

The empty path segment created by `//` may cause issues with Transifex push/pull operations.

## Changes

- Fixed 69 `file_filter` paths in `.tx/config` by replacing `locale//<lang>` with `locale/<lang>`
- No other files modified

## Validation

- Verified all 69 `file_filter` entries now use single-slash `locale/<lang>/LC_MESSAGES/` paths with no remaining double slashes
- Confirmed `.tx/config` parses correctly (no syntax errors in section headers or key-value pairs)
- Ran `make html` — Sphinx build succeeded with no new warnings or errors introduced by this change (all 178 warnings are pre-existing)

<details>
<summary>Build output (Sphinx)</summary>

```
$ make html
build succeeded, 178 warnings.
The HTML pages are in _build/html.
```

All 178 warnings are pre-existing and unrelated to this PR:
- `git.too_shallow` warnings (shallow clone, no git timestamps for source files)
- `myst.xref_missing` warnings (DIP README cross-reference targets in `docs/core/dips/`)
- `RemovedInSphinx90Warning` deprecation notices from hoverxref extension

No new warnings or errors introduced by this change.

**Environment:** Python 3.14.3, Sphinx 8.1.3, macOS (arm64)
</details>
