### PR TITLE
docs: clarify evonode CPU requirements (x86-64-v3)

### DIFF
--- a/docs/user/masternodes/understanding.rst
+++ b/docs/user/masternodes/understanding.rst
@@ -421,7 +421,11 @@ Core. To support the network effectively, the following requirements are recomme
 
 .. note::
 
-  Intel CPUs should be `Haswell architecture <https://en.wikipedia.org/wiki/Haswell_(microarchitecture)>`_ or newer
+  Platform release builds target the `x86-64-v3 <https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels>`_
+  microarchitecture level. Most Intel `Haswell <https://en.wikipedia.org/wiki/Haswell_(microarchitecture)>`_
+  (2013) and newer CPUs, as well as AMD Excavator (2015) and newer CPUs, support this level.
+  However, some older Haswell-era processors (e.g. certain Xeon E5 v3 steppings with TSX disabled)
+  may not be compatible. ARM64 hosts are also supported.
 
 +---------+------------------+
 |         | Recommended      |


### PR DESCRIPTION
## Summary

Update the evonode hardware requirements note to explicitly reference the **x86-64-v3** microarchitecture level instead of the vague "Haswell or newer" language.

## Changes

- Replaces the generic "Intel CPUs should be Haswell architecture or newer" note with specific x86-64-v3 targeting information
- Notes that most Intel Haswell (2013+) and AMD Excavator (2015+) CPUs support this level
- Calls out the known incompatibility with certain Xeon E5 v3 steppings (TSX disabled via microcode)
- Notes ARM64 host support

## Context

Platform release builds have targeted x86-64-v3 since PR dashpay/platform#2374 (Dec 2024). Issue dashpay/platform#2442 reported that certain Haswell-era Xeon processors fail at runtime despite nominally supporting the x86-64-v3 instruction set. The previous docs language was misleading.

Closes dashpay/platform#2442

<!-- Replace -->
Preview build: https://dash-docs--570.org.readthedocs.build/en/570/
<!-- Replace -->
