### PR TITLE
Update integration-apis.rst

### DIFF
--- a/docs/user/developers/integration-apis.rst
+++ b/docs/user/developers/integration-apis.rst
@@ -112,6 +112,20 @@ and easy way to start accepting payments in cryptocurrency.
   year free, then $49/month 
 - Documentation: https://docs.blockmove.io
 
+GetBlock
+--------
+https://getblock.io/
+
+GetBlock provides reliable and scalable RPC access to Dash mainnet
+through shared and dedicated nodes. Its endpoints are useful for
+developers, wallets, exchanges, crypto miners, hardware wallet
+providers, and businesses that need stable access to the Dash network.
+
+- Features: JSON-RPC, REST, Blockbook (REST), Blockbook (WebSocket)
+- Pricing Model: Free up to 50K CUs, paid shared- and dedicated-node
+pricing
+- Documentation: https://docs.getblock.io/
+
 
 NOWNodes
 --------


### PR DESCRIPTION
Add GetBlock to API Services

<!-- Replace -->
Preview build: https://dash-docs--576.org.readthedocs.build/en/576/
<!-- Replace -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GetBlock API provider documentation section to integration APIs guide, including details on supported protocols (JSON-RPC, REST, Blockbook via REST/WebSocket), pricing model (free tier up to 50K CUs with shared/dedicated node options), and references to provider resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->