### PR TITLE
Add certificate renewal troubleshooting for evonodes

### DIFF
--- a/docs/user/masternodes/index.rst
+++ b/docs/user/masternodes/index.rst
@@ -57,3 +57,4 @@ a self-operated masternode.
    setup-evonode
    setup-testnet.rst
    maintenance.rst
+   troubleshooting-certificates.rst

--- a/docs/user/masternodes/troubleshooting-certificates.rst
+++ b/docs/user/masternodes/troubleshooting-certificates.rst
@@ -27,8 +27,8 @@ Inbound port 80 is a permanent requirement
 This is the single most common cause, and the most commonly misunderstood.
 
 When dashmate obtains a certificate for you — the Let's Encrypt and ZeroSSL options — the authority
-proves you control your IP address by connecting **to** your node on port 80 and reading a file
-dashmate serves there for a few seconds. This happens on **every issuance and every renewal**, not
+proves you control your IP address by connecting to your node on port 80 and reading a file
+dashmate serves there for a few seconds. This happens on every issuance and every renewal, not
 only during setup. It does not apply if you upload a certificate yourself.
 
 Let's Encrypt certificates for IP addresses are :ref:`short-lived <evonode-ssl-cert>` — about 160
@@ -44,7 +44,7 @@ dark within a week.
 Why you cannot test port 80 with a port scanner
 -----------------------------------------------
 
-An external port check on port 80 will report it **closed on a perfectly healthy node**, and this
+An external port check on port 80 will report it closed on a perfectly healthy node, and this
 confuses almost everyone who tries it.
 
 Nothing listens on port 80 on a normal evonode. Dashmate starts a listener only for the few seconds
@@ -84,24 +84,24 @@ The certificate authority could not reach this node on port 80
 Nothing usable answered. Which of two things happened is worth knowing, and ``dashmate doctor``
 shows the authority's own words:
 
-- **Timed out.** The connection went nowhere and nothing replied — a firewall dropping it silently.
+- Timed out. The connection went nowhere and nothing replied — a firewall dropping it silently.
   Work through the three layers below.
-- **Refused.** Something reachable actively rejected the connection, so the packets arrive but
+- Refused. Something reachable actively rejected the connection, so the packets arrive but
   nothing is listening when they do. Check that port 80 is forwarded to *this* machine, then look
   at what dashmate reported: ``dashmate logs <config> dashmate_helper``.
 
 For a timeout, check all three layers — a rule on one does not help if another blocks it:
 
-#. **The machine's own firewall.** On Ubuntu with ``ufw``::
+#. The machine's own firewall. On Ubuntu with ``ufw``::
 
       sudo ufw allow 80/tcp
       sudo ufw status
 
-#. **Your hosting provider's firewall.** Many providers (AWS security groups, Hetzner Cloud
+#. Your hosting provider's firewall. Many providers (AWS security groups, Hetzner Cloud
    firewalls, OVH, Vultr, DigitalOcean) apply a second firewall outside the machine, configured in
    their web console. Port 80 must be allowed there too.
 
-#. **Your router**, if the node is behind NAT. Forward inbound port 80 to the node's internal
+#. Your router, if the node is behind NAT. Forward inbound port 80 to the node's internal
    address.
 
 Once the port is open, wait for the next automatic attempt — the doctor tells you when that is. You
@@ -121,7 +121,7 @@ Check the machine first::
 If that lists a process (nginx, Apache, Caddy, another container), stop it or move it to a different
 port. Dashmate needs port 80 free to answer the challenge.
 
-If it lists **nothing**, then something upstream is answering instead of your node — check your
+If it lists nothing, then something upstream is answering instead of your node — check your
 router's port forwarding and your hosting provider's configuration.
 
 Something on this machine is already using port 80
@@ -152,9 +152,9 @@ The certificate authority has temporarily refused this address
 
 Let's Encrypt applies two separate limits, and they are easy to confuse:
 
-- **Five failed validations per hour**, counted per ACME account and address. This is the one you
+- Five failed validations per hour, counted per ACME account and address. This is the one you
   hit by retrying after a failure, and dashmate's own automatic renewal draws on the same budget.
-- **Five certificates per week** for the same address. This one is spent by *successful* issuance,
+- Five certificates per week for the same address. This one is spent by *successful* issuance,
   which is why a certificate that was issued but never saved still counts.
 
 .. important::
@@ -176,12 +176,12 @@ Check free disk space and the permissions on your dashmate directory first, then
 Avoid making it worse
 =====================
 
-- **Do not repeatedly run** ``dashmate ssl obtain``. Failed attempts are rate-limited by the
+- Do not repeatedly run ``dashmate ssl obtain``. Failed attempts are rate-limited by the
   certificate authority and shared with automatic renewal, so retrying without changing anything
   makes recovery slower.
-- **Do not switch provider hoping it helps.** If port 80 is unreachable, every provider fails the
+- Do not switch provider hoping it helps. If port 80 is unreachable, every provider fails the
   same way — they all validate the same route.
-- **Do not rely on an external port check.** See :ref:`above <evonode-cert-port-80>`.
+- Do not rely on an external port check. See :ref:`above <evonode-cert-port-80>`.
 
 Getting help
 ============

--- a/docs/user/masternodes/troubleshooting-certificates.rst
+++ b/docs/user/masternodes/troubleshooting-certificates.rst
@@ -110,8 +110,10 @@ Check the machine first::
 
    sudo ss -lntp 'sport = :80'
 
-If that lists a process (e.g., nginx, Apache, Caddy, another container), stop it or move it to a
-different port. Dashmate needs port 80 free to answer the challenge.
+If that lists a process (e.g., nginx, Apache, Caddy, another container), certificate renewals will
+continue to fail until the port is released. Reconfigure the process to use a different port where
+possible. Otherwise, stop it before the next scheduled renewal attempt and leave it stopped until
+the renewal completes.
 
 If it lists nothing, then something upstream is answering instead of your node. Check your router's
 port forwarding and your hosting provider's configuration.

--- a/docs/user/masternodes/troubleshooting-certificates.rst
+++ b/docs/user/masternodes/troubleshooting-certificates.rst
@@ -26,9 +26,10 @@ Inbound port 80 is a permanent requirement
 
 This is the single most common cause, and the most commonly misunderstood.
 
-Both Let's Encrypt and ZeroSSL prove that you control your IP address by connecting **to** your node
-on port 80 and reading a file dashmate serves there for a few seconds. This happens on **every
-issuance and every renewal**, not only during setup.
+When dashmate obtains a certificate for you — the Let's Encrypt and ZeroSSL options — the authority
+proves you control your IP address by connecting **to** your node on port 80 and reading a file
+dashmate serves there for a few seconds. This happens on **every issuance and every renewal**, not
+only during setup. It does not apply if you upload a certificate yourself.
 
 Let's Encrypt certificates for IP addresses are :ref:`short-lived <evonode-ssl-cert>` — about 160
 hours — and dashmate renews them a couple of days before they expire. So a firewall rule that was
@@ -80,15 +81,21 @@ Causes and what to do about each
 The certificate authority could not reach this node on port 80
 --------------------------------------------------------------
 
-Nothing answered. The connection was dropped or refused before it arrived, which means a firewall
-somewhere between the internet and your node.
+Nothing usable answered. Which of two things happened is worth knowing, and ``dashmate doctor``
+shows the authority's own words:
 
-Check all three layers — a rule on one does not help if another blocks it:
+- **Timed out.** The connection went nowhere and nothing replied — a firewall dropping it silently.
+  Work through the three layers below.
+- **Refused.** Something reachable actively rejected the connection, so the packets arrive but
+  nothing is listening when they do. Check that port 80 is forwarded to *this* machine, then look
+  at what dashmate reported: ``dashmate logs <config> dashmate_helper``.
+
+For a timeout, check all three layers — a rule on one does not help if another blocks it:
 
 #. **The machine's own firewall.** On Ubuntu with ``ufw``::
 
-      ufw allow 80/tcp
-      ufw status
+      sudo ufw allow 80/tcp
+      sudo ufw status
 
 #. **Your hosting provider's firewall.** Many providers (AWS security groups, Hetzner Cloud
    firewalls, OVH, Vultr, DigitalOcean) apply a second firewall outside the machine, configured in
@@ -127,8 +134,10 @@ with the ``ss`` command above.
 The free ZeroSSL account has used all three of its certificates
 ----------------------------------------------------------------
 
-A free ZeroSSL account allows three certificates in total, so renewals stop permanently after about
-270 days. This is not something you can wait out or repair — ZeroSSL will not issue another one.
+Dashmate obtains ZeroSSL certificates through ZeroSSL's own API, and :ref:`a free account allows
+3 certificates <evonode-ssl-cert>` — or 3 renewals of one certificate — in total. Renewals stop
+permanently after that. It is not something you can wait out or repair; ZeroSSL will not issue
+another one on that plan.
 
 Switch to Let's Encrypt, which is free and does not cap certificates this way::
 

--- a/docs/user/masternodes/troubleshooting-certificates.rst
+++ b/docs/user/masternodes/troubleshooting-certificates.rst
@@ -1,0 +1,187 @@
+.. meta::
+   :description: How to diagnose and fix TLS certificate renewal problems on a Dash evonode, including inbound port 80 requirements for Let's Encrypt and ZeroSSL
+   :keywords: dash, cryptocurrency, masternode, evonode, certificate, ssl, tls, port 80, lets encrypt, zerossl, acme, renewal, troubleshooting
+
+.. _evonode-cert-troubleshooting:
+
+===================================
+Certificate renewal troubleshooting
+===================================
+
+Your evonode serves Dash Platform over TLS, so it needs a valid certificate at all times. Dashmate
+obtains that certificate for you and renews it automatically, but renewal can stop working long
+after setup succeeded — and when it does, nothing warns you until the certificate expires and your
+node stops accepting clients.
+
+Serving an expired certificate is one of the most common faults on mainnet evonodes, and almost all
+of it comes down to the causes below.
+
+This page explains why renewal fails, how to find out which cause applies to your node, and what to
+do about each one.
+
+.. _evonode-cert-port-80:
+
+Inbound port 80 is a permanent requirement
+==========================================
+
+This is the single most common cause, and the most commonly misunderstood.
+
+Both Let's Encrypt and ZeroSSL prove that you control your IP address by connecting **to** your node
+on port 80 and reading a file dashmate serves there for a few seconds. This happens on **every
+issuance and every renewal**, not only during setup.
+
+Let's Encrypt certificates for IP addresses are :ref:`short-lived <evonode-ssl-cert>` — about 160
+hours — and dashmate renews them a couple of days before they expire. So a firewall rule that was
+opened once for setup and closed afterwards, or one that does not survive a reboot, takes your node
+dark within a week.
+
+.. warning::
+
+   Inbound port 80 must stay open permanently. Nothing warns you when it stops being reachable, and
+   the certificate you are currently serving keeps working until it expires.
+
+Why you cannot test port 80 with a port scanner
+-----------------------------------------------
+
+An external port check on port 80 will report it **closed on a perfectly healthy node**, and this
+confuses almost everyone who tries it.
+
+Nothing listens on port 80 on a normal evonode. Dashmate starts a listener only for the few seconds
+a renewal takes, and shuts it down again immediately. So a scanner that happens to check at any
+other moment finds nothing — which is exactly what a healthy node looks like.
+
+.. note::
+
+   A "port 80 closed" result from an online port checker tells you nothing about whether certificate
+   renewal works. Do not rewrite firewall rules based on it.
+
+The reliable way to find out is to ask your node what actually happened the last time it tried.
+
+.. _evonode-cert-diagnose:
+
+Find out what is actually wrong
+===============================
+
+Run the doctor::
+
+   dashmate doctor
+
+Dashmate records the outcome of every scheduled renewal, so the doctor reports the reason the
+certificate authority gave rather than guessing. Work from what it tells you.
+
+If the doctor reports no problem with your certificate, renewal is working and there is nothing to
+do here.
+
+.. _evonode-cert-causes:
+
+Causes and what to do about each
+================================
+
+The certificate authority could not reach this node on port 80
+--------------------------------------------------------------
+
+Nothing answered. The connection was dropped or refused before it arrived, which means a firewall
+somewhere between the internet and your node.
+
+Check all three layers — a rule on one does not help if another blocks it:
+
+#. **The machine's own firewall.** On Ubuntu with ``ufw``::
+
+      ufw allow 80/tcp
+      ufw status
+
+#. **Your hosting provider's firewall.** Many providers (AWS security groups, Hetzner Cloud
+   firewalls, OVH, Vultr, DigitalOcean) apply a second firewall outside the machine, configured in
+   their web console. Port 80 must be allowed there too.
+
+#. **Your router**, if the node is behind NAT. Forward inbound port 80 to the node's internal
+   address.
+
+Once the port is open, wait for the next automatic attempt — the doctor tells you when that is. You
+do not need to run any command.
+
+Something answered on port 80, but not this node's certificate check
+--------------------------------------------------------------------
+
+The certificate authority reached your address and got the wrong response. Something else is
+answering: another web server on the machine, a reverse proxy in front of it, or a router forwarding
+port 80 somewhere other than your node.
+
+Check the machine first::
+
+   sudo ss -lntp 'sport = :80'
+
+If that lists a process (nginx, Apache, Caddy, another container), stop it or move it to a different
+port. Dashmate needs port 80 free to answer the challenge.
+
+If it lists **nothing**, then something upstream is answering instead of your node — check your
+router's port forwarding and your hosting provider's configuration.
+
+Something on this machine is already using port 80
+---------------------------------------------------
+
+Dashmate could not start its own listener because the port is taken. Note this is the opposite
+problem to an unreachable port: the port is reachable, it is occupied. Find and stop the occupant
+with the ``ss`` command above.
+
+The free ZeroSSL account has used all three of its certificates
+----------------------------------------------------------------
+
+A free ZeroSSL account allows three certificates in total, so renewals stop permanently after about
+270 days. This is not something you can wait out or repair — ZeroSSL will not issue another one.
+
+Switch to Let's Encrypt, which is free and does not cap certificates this way::
+
+   dashmate ssl obtain --config mainnet --provider letsencrypt
+
+This still needs inbound port 80 open to the internet, permanently. If you cannot open port 80,
+there is no other way to obtain a certificate for an IP address automatically — see
+:ref:`SSL certificates <evonode-ssl-cert>` for the manual upload option.
+
+The certificate authority has temporarily refused this address
+---------------------------------------------------------------
+
+Let's Encrypt limits how often a single address may fail validation — five failed attempts per hour,
+and that budget is shared with dashmate's own automatic renewal.
+
+.. important::
+
+   Do not keep running the obtain command. Each attempt spends part of this budget and makes the
+   situation last longer. Fix the underlying cause first, then let the automatic retry run.
+
+A certificate was issued but dashmate could not save it
+--------------------------------------------------------
+
+The certificate authority issued a certificate that never reached disk. That issuance is spent
+against your weekly limit whether or not it arrived, so requesting another one immediately spends a
+second one to fix a problem that is local to your machine.
+
+Check free disk space and the permissions on your dashmate directory first, then obtain again.
+
+.. _evonode-cert-avoid:
+
+Avoid making it worse
+=====================
+
+- **Do not repeatedly run** ``dashmate ssl obtain``. Failed attempts are rate-limited by the
+  certificate authority and shared with automatic renewal, so retrying without changing anything
+  makes recovery slower.
+- **Do not switch provider hoping it helps.** If port 80 is unreachable, every provider fails the
+  same way — they all validate the same route.
+- **Do not rely on an external port check.** See :ref:`above <evonode-cert-port-80>`.
+
+Getting help
+============
+
+If the doctor cannot determine the cause, or the remedy does not work, collect a report and send it
+to the support team::
+
+   dashmate doctor report
+
+The report includes the recorded renewal outcome along with service logs and system information.
+Review it before sharing: it contains your node's IP address and configuration.
+
+.. seealso::
+
+   - :ref:`SSL certificates <evonode-ssl-cert>` — choosing and configuring a certificate provider
+   - :ref:`Server configuration <server-config>` — firewall setup

--- a/docs/user/masternodes/troubleshooting-certificates.rst
+++ b/docs/user/masternodes/troubleshooting-certificates.rst
@@ -10,46 +10,40 @@ Certificate renewal troubleshooting
 
 Your evonode serves Dash Platform over TLS, so it needs a valid certificate at all times. Dashmate
 obtains that certificate for you and renews it automatically, but renewal can stop working long
-after setup succeeded — and when it does, nothing warns you until the certificate expires and your
-node stops accepting clients.
+after setup succeeded. If renewal fails without you noticing it, your node will stop accepting
+clients once the certificate expires.
 
-Serving an expired certificate is one of the most common faults on mainnet evonodes, and almost all
-of it comes down to the causes below.
-
-This page explains why renewal fails, how to find out which cause applies to your node, and what to
-do about each one.
+Serving expired certificates is one of the most common connection issues on mainnet evonodes. Use
+the info on this page to find and fix certificate renewal failures on your evonode.
 
 .. _evonode-cert-port-80:
 
 Inbound port 80 is a permanent requirement
 ==========================================
 
-This is the single most common cause, and the most commonly misunderstood.
-
-When dashmate obtains a certificate for you — the Let's Encrypt and ZeroSSL options — the authority
-proves you control your IP address by connecting to your node on port 80 and reading a file
-dashmate serves there for a few seconds. This happens on every issuance and every renewal, not
-only during setup. It does not apply if you upload a certificate yourself.
+This cause is common and often misunderstood. When dashmate obtains a certificate for you using
+Let's Encrypt or ZeroSSL, the authority proves you control your IP address by connecting to your
+node on port 80 and reading a file dashmate temporarily serves there. This happens on every issuance
+and every renewal, not only during setup. It does not apply if you upload a certificate yourself.
 
 Let's Encrypt certificates for IP addresses are :ref:`short-lived <evonode-ssl-cert>` — about 160
-hours — and dashmate renews them a couple of days before they expire. So a firewall rule that was
-opened once for setup and closed afterwards, or one that does not survive a reboot, takes your node
-dark within a week.
+hours — and dashmate renews them a couple of days before they expire. So a non-permanent firewall
+rule can result in your node having an expired certificate within a week.
 
 .. warning::
 
-   Inbound port 80 must stay open permanently. Nothing warns you when it stops being reachable, and
-   the certificate you are currently serving keeps working until it expires.
+   Inbound port 80 must stay open permanently. Dashmate does not warn you when it stops being
+   reachable. The certificate you are serving just becomes invalid when it expires.
+
+.. _evonode-cert-port-80-scan:
 
 Why you cannot test port 80 with a port scanner
 -----------------------------------------------
 
-An external port check on port 80 will report it closed on a perfectly healthy node, and this
-confuses almost everyone who tries it.
-
-Nothing listens on port 80 on a normal evonode. Dashmate starts a listener only for the few seconds
-a renewal takes, and shuts it down again immediately. So a scanner that happens to check at any
-other moment finds nothing — which is exactly what a healthy node looks like.
+Since nothing continuously listens to port 80 on a normal evonode, an external port check will
+report it closed even on healthy nodes. Dashmate starts a listener only for the few seconds a
+renewal takes, and shuts it down again immediately. A scanner that checks at any other time will
+find nothing.
 
 .. note::
 
@@ -68,10 +62,8 @@ Run the doctor::
    dashmate doctor
 
 Dashmate records the outcome of every scheduled renewal, so the doctor reports the reason the
-certificate authority gave rather than guessing. Work from what it tells you.
-
-If the doctor reports no problem with your certificate, renewal is working and there is nothing to
-do here.
+certificate authority gave rather than guessing. If the doctor reports no problem with your
+certificate, renewal is working and there is nothing to do here.
 
 .. _evonode-cert-causes:
 
@@ -84,13 +76,13 @@ The certificate authority could not reach this node on port 80
 Nothing usable answered. Which of two things happened is worth knowing, and ``dashmate doctor``
 shows the authority's own words:
 
-- Timed out. The connection went nowhere and nothing replied — a firewall dropping it silently.
-  Work through the three layers below.
-- Refused. Something reachable actively rejected the connection, so the packets arrive but
-  nothing is listening when they do. Check that port 80 is forwarded to *this* machine, then look
+- **Timed out**. The connection went nowhere and nothing replied because a firewall dropped it
+  silently. Work through the three layers below.
+- **Refused**. Something reachable actively rejected the connection, so the packets arrive but
+  nothing is listening when they do. Check that port 80 is forwarded to the evonode, then look
   at what dashmate reported: ``dashmate logs <config> dashmate_helper``.
 
-For a timeout, check all three layers — a rule on one does not help if another blocks it:
+For a timeout, check all three layers. Connections could be blocked at any or all layers:
 
 #. The machine's own firewall. On Ubuntu with ``ufw``::
 
@@ -104,7 +96,7 @@ For a timeout, check all three layers — a rule on one does not help if another
 #. Your router, if the node is behind NAT. Forward inbound port 80 to the node's internal
    address.
 
-Once the port is open, wait for the next automatic attempt — the doctor tells you when that is. You
+Once the port is open, wait for the next automatic attempt at the time indicated by the doctor. You
 do not need to run any command.
 
 Something answered on port 80, but not this node's certificate check
@@ -118,11 +110,11 @@ Check the machine first::
 
    sudo ss -lntp 'sport = :80'
 
-If that lists a process (nginx, Apache, Caddy, another container), stop it or move it to a different
-port. Dashmate needs port 80 free to answer the challenge.
+If that lists a process (e.g., nginx, Apache, Caddy, another container), stop it or move it to a
+different port. Dashmate needs port 80 free to answer the challenge.
 
-If it lists nothing, then something upstream is answering instead of your node — check your
-router's port forwarding and your hosting provider's configuration.
+If it lists nothing, then something upstream is answering instead of your node. Check your router's
+port forwarding and your hosting provider's configuration.
 
 Something on this machine is already using port 80
 ---------------------------------------------------
@@ -144,8 +136,8 @@ Switch to Let's Encrypt, which is free and does not cap certificates this way::
    dashmate ssl obtain --config mainnet --provider letsencrypt
 
 This still needs inbound port 80 open to the internet, permanently. If you cannot open port 80,
-there is no other way to obtain a certificate for an IP address automatically — see
-:ref:`SSL certificates <evonode-ssl-cert>` for the manual upload option.
+there is no other way to automatically obtain a certificate for an IP address. See :ref:`SSL
+certificates <evonode-ssl-cert>` for the manual upload option.
 
 The certificate authority has temporarily refused this address
 ---------------------------------------------------------------
@@ -179,15 +171,15 @@ Avoid making it worse
 - Do not repeatedly run ``dashmate ssl obtain``. Failed attempts are rate-limited by the
   certificate authority and shared with automatic renewal, so retrying without changing anything
   makes recovery slower.
-- Do not switch provider hoping it helps. If port 80 is unreachable, every provider fails the
-  same way — they all validate the same route.
-- Do not rely on an external port check. See :ref:`above <evonode-cert-port-80>`.
+- Do not switch provider hoping it helps. If port 80 is unreachable, every provider will fail in the
+  same way since they all validate the same route.
+- Do not rely on an external port check. See :ref:`above <evonode-cert-port-80-scan>`.
 
 Getting help
 ============
 
-If the doctor cannot determine the cause, or the remedy does not work, collect a report and send it
-to the support team::
+If the doctor cannot determine the cause, or the fix does not work, collect a report and send it to
+the support team::
 
    dashmate doctor report
 

--- a/docs/user/masternodes/troubleshooting-certificates.rst
+++ b/docs/user/masternodes/troubleshooting-certificates.rst
@@ -150,8 +150,12 @@ there is no other way to obtain a certificate for an IP address automatically â€
 The certificate authority has temporarily refused this address
 ---------------------------------------------------------------
 
-Let's Encrypt limits how often a single address may fail validation â€” five failed attempts per hour,
-and that budget is shared with dashmate's own automatic renewal.
+Let's Encrypt applies two separate limits, and they are easy to confuse:
+
+- **Five failed validations per hour**, counted per ACME account and address. This is the one you
+  hit by retrying after a failure, and dashmate's own automatic renewal draws on the same budget.
+- **Five certificates per week** for the same address. This one is spent by *successful* issuance,
+  which is why a certificate that was issued but never saved still counts.
 
 .. important::
 
@@ -161,8 +165,8 @@ and that budget is shared with dashmate's own automatic renewal.
 A certificate was issued but dashmate could not save it
 --------------------------------------------------------
 
-The certificate authority issued a certificate that never reached disk. That issuance is spent
-against your weekly limit whether or not it arrived, so requesting another one immediately spends a
+The certificate authority issued a certificate that never reached disk. It counts against the
+five-per-week limit above whether or not it arrived, so requesting another one immediately spends a
 second one to fix a problem that is local to your machine.
 
 Check free disk space and the permissions on your dashmate directory first, then obtain again.


### PR DESCRIPTION
## What this adds

A new page — **Certificate renewal troubleshooting** (`docs/user/masternodes/troubleshooting-certificates.rst`) — plus a toctree entry.

## Why

Inbound port 80 is currently documented as a **setup step**. The requirement is actually permanent: Let's Encrypt IP certificates are short-lived (~160 hours) and dashmate reissues them every few days, so a firewall rule that was opened once for setup, or that does not survive a reboot, takes a node dark within a week. Nothing warns the operator until the certificate expires and clients stop connecting.

Serving an expired certificate is one of the most common faults on mainnet evonodes today.

There was no troubleshooting content for this anywhere. `maintenance.rst` has a two-line "Dashmate troubleshooting" section pointing at `dashmate doctor`, which is described elsewhere as a log collector rather than a diagnostic.

## The part that matters most

**An external port check reports port 80 closed on a perfectly healthy node.** Nothing listens there except for the few seconds a renewal takes, so a scanner checking at any other moment finds nothing — which is exactly what a working node looks like.

Operators reach for that check first, get a false negative, and rewrite firewall rules that were already correct. The page says this explicitly and points them at `dashmate doctor` instead, which reads the recorded outcome of the last renewal attempt.

## Also covered

Each cause an operator can actually act on, and specifically the ones where obtaining another certificate **makes things worse**:

- Nothing reached port 80 — all three firewall layers (host, hosting provider, router/NAT)
- Something else answered on port 80 — and why `ss` returning nothing means the problem is upstream
- Port 80 occupied locally — the opposite problem, opposite fix
- ZeroSSL free tier exhausted — terminal; switch provider
- Rate limited — do not retry, and why
- Issued but not saved — the issuance is already spent

## Related

Dashmate is gaining the ability to name these causes rather than guess at them (dashpay/platform#4476). Once this page is live it would be worth a short redirect (e.g. `docs.dash.org/evonode-cert-port80`) so dashmate can link to it from the doctor's output without pinning a full path — the existing full-path link in dashmate's doctor (`/en/stable/masternodes/dashmate.html#ssl-certificate`) currently 404s after a docs reorganisation.

## Testing

`make html` builds the page cleanly; cross-references to `evonode-ssl-cert` and `server-config` resolve.

<!-- Replace -->
Preview build: https://dash-docs--589.org.readthedocs.build/en/589/
<!-- Replace -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting guide for evonode TLS certificate renewal.
  * Clarified port 80 renewal behavior, firewall and routing checks, port conflicts, provider changes, and certificate limits.
  * Added guidance for interpreting port-scanner results, doctor output, and connection failures.
  * Documented recovery steps and instructions for collecting support reports.
  * Linked the new guide from the masternode documentation contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->